### PR TITLE
remove global .env from gitingore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,7 @@ typings/
 .yarn-integrity
 
 # dotenv environment variables file
-.env
+.env.local
 
 # next.js build output
 .next

--- a/packages/client/.env
+++ b/packages/client/.env
@@ -1,0 +1,3 @@
+REACT_APP_VERSION=$npm_package_version
+REACT_APP_NAME=$npm_package_name
+REACT_APP_SERVER_PATH='https://serge-dev.herokuapp.com'


### PR DESCRIPTION
## 🧰 Ticket
fix #14

## 🚀 Overview: 
add in to client folder main .env file with required options
replace .env from .gitignore to .env.local. So global configs should be in .env file and local configs (replacements/or secret/servers side data) in .env.local file

## 🔗 Link to preview
[If you're on a project which auto-deploys branches, link to the branches preview link here]

## 🤔 Reason: 
[Why did you do what you did? - feel free to copy from the ticket if the reason is there]

## 🔨Work carried out:

[A list of work you have done, use [markdown checklist format](https://github.blog/2013-01-09-task-lists-in-gfm-issues-pulls-comments/), if you leave any boxes unchecked, be sure to set this PR as a draft]

- [x] Tests pass

## 🖥️ Screenshot
[If the work is UI related then paste a screenshot of the update here.]

## 📝 Developer Notes:
[Sometimes, extra notes are needed to add clarity to a PR, add them here]