### PR TITLE
Fix demo password list overflow

### DIFF
--- a/packages/client/src/Views/PlayerUiLobby.jsx
+++ b/packages/client/src/Views/PlayerUiLobby.jsx
@@ -53,7 +53,7 @@ export default function PlayerUiLobby ({ wargameList, roleOptions, checkPassword
           {selectedWargame && state.showAccessCodes &&
           <div className="demo-passwords">
             <h3>Not visible in production</h3>
-            <ul>
+            <ul className="demo-list-forces">
               {roleOptions.map((force) => {
                 return (
                   <li key={force.name} className="list-item-demo-passwords">

--- a/packages/themes/demo.scss
+++ b/packages/themes/demo.scss
@@ -166,3 +166,9 @@
     }
   }
 }
+
+.demo-list-forces {
+  max-height: 45vh;
+  overflow: auto;
+  margin-top: 25px;
+}


### PR DESCRIPTION
## 🧰 Ticket
Closes #35 

## 🚀 Overview: 
Update styling for demo password list section

## 🤔 Reason: 
For a wargame, game control has created lots of forces, and lots of roles in those forces.

At the player welcome screen, eventually the list on the left-hand side becomes taller than the screen. But, no scroll bars are offered - making it impossible to select some roles.

## 🔨Work carried out:

- [x] Add new class selector
- [x] Add new CSS rules
- [x] Tests pass
[List of roles can get too tall for Player Screen](https://app.gitkraken.com/glo/board/XZIuhoko5QAPaF0f/card/XbL5EtnTpQAP1k-J)