### PR TITLE
Fix message got cleared out in content editor

### DIFF
--- a/packages/client/src/Components/MessageCreatorChatChannel.jsx
+++ b/packages/client/src/Components/MessageCreatorChatChannel.jsx
@@ -37,6 +37,7 @@ class JsonCreator extends Component {
     if (this.editor.getValue().content === "") return;
 
     saveMessage(state.currentWargame, messageDetails, this.editor.getValue())();
+    this.setupEditor();
   };
 
   setupEditor() {
@@ -59,10 +60,6 @@ class JsonCreator extends Component {
   }
 
   componentDidMount() {
-    this.setupEditor();
-  }
-
-  componentDidUpdate() {
     this.setupEditor();
   }
 


### PR DESCRIPTION
## 🧰 Ticket
Closes #34 

## 🚀 Overview: 
Apply setup editor after saving message instead of on every updates

## 🤔 Reason: 
Each time any new message was received, the contents of the Game Admin text box was emptied.

## 🔨Work carried out:
- [x] Minor refactor on gameAdmin component
- [x] Tests pass
[Game Control message wiped on receipt of new channel message](https://app.gitkraken.com/glo/board/XZIuhoko5QAPaF0f/card/XbL40Dz-owAP0sjg)