### PR TITLE
Fix incorrect templates assignment

### DIFF
--- a/packages/client/src/ActionsAndReducers/playerUi/playerUi_Reducer.js
+++ b/packages/client/src/ActionsAndReducers/playerUi/playerUi_Reducer.js
@@ -173,14 +173,14 @@ export const playerUiReducer = (state = initialState, action) => {
             (channelActive || allRoles) &&
             !newState.channels[channel.uniqid]
           ) {
-            const participatingRole = channel.participants.some((p) => p.forceUniqid === newState.selectedForce && p.roles.some((role) => role.value === newState.selectedRole))
+            const participatingRole = channel.participants.find((p) => p.forceUniqid === newState.selectedForce && p.roles.some((role) => role.value === newState.selectedRole))
             const participatingForce = channel.participants.find((p) => p.forceUniqid === newState.selectedForce)
 
             if (!participatingForce && !newState.isObserver) return
 
             const isParticipant = !!participatingRole
             const allRolesIncluded = channel.participants.some((p) => p.forceUniqid === newState.selectedForce && p.roles.length === 0)
-            const chosenTemplates = participatingForce.templates
+            const chosenTemplates = participatingRole.templates
 
             let templates
             if (isParticipant || allRolesIncluded) {
@@ -257,7 +257,7 @@ export const playerUiReducer = (state = initialState, action) => {
       newState.chatChannel.messages = messages.filter((message) => message.details.channel === newState.chatChannel.name)
 
       newState.allChannels.forEach((channel) => {
-        const participatingRole = channel.participants.some((p) => p.forceUniqid === newState.selectedForce && p.roles.some((role) => role.value === newState.selectedRole))
+        const participatingRole = channel.participants.find((p) => p.forceUniqid === newState.selectedForce && p.roles.some((role) => role.value === newState.selectedRole))
         const participatingForce = channel.participants.find((p) => p.forceUniqid === newState.selectedForce)
 
         if (!participatingForce && !newState.isObserver) return
@@ -267,7 +267,7 @@ export const playerUiReducer = (state = initialState, action) => {
 
         let chosenTemplates
         if (participatingForce) {
-          chosenTemplates = participatingForce.templates
+          chosenTemplates = participatingRole.templates
         } else {
           chosenTemplates = []
         }

--- a/packages/client/src/ActionsAndReducers/playerUi/playerUi_Reducer.js
+++ b/packages/client/src/ActionsAndReducers/playerUi/playerUi_Reducer.js
@@ -266,7 +266,7 @@ export const playerUiReducer = (state = initialState, action) => {
         const allRolesIncluded = channel.participants.some((p) => p.forceUniqid === newState.selectedForce && p.roles.length === 0)
 
         let chosenTemplates
-        if (participatingForce) {
+        if (participatingRole) {
           chosenTemplates = participatingRole.templates
         } else {
           chosenTemplates = []


### PR DESCRIPTION
## 🧰 Ticket
Closes #33 

## 🚀 Overview: 
Select templates based on current role instead of current  force

## 🤔 Reason: 
when we retrieve the message types for a force-role, we just retrieve the first message-type description for that force. Instead, we should show the "union" of all message types allocated to that force-role in that channel.

## 🔨Work carried out:

- [x] Update templates assignment on `SET_ALL_MESSAGES` action
- [x] Update templates assignment on `SET_LATEST_WARGAME_MESSAGE` action
- [x] Tests pass
[Logic bug in providing templates for player](https://app.gitkraken.com/glo/board/XZIuhoko5QAPaF0f/card/XbL4AdnTpQAP1k_h)