### PR TITLE
Fix tab not rendered on removal

### DIFF
--- a/packages/client/src/Views/ChannelTabsContainer.jsx
+++ b/packages/client/src/Views/ChannelTabsContainer.jsx
@@ -114,8 +114,11 @@ class ChannelTabsContainer extends Component {
   factory = (node) => {
     const [ state ] = this.context;
     if (_.isEmpty(state.channels)) return;
-    let curChannelEntry = Object.entries(state.channels).find((entry) => entry[1].name === node.getName());
-    return <Channel channel={curChannelEntry[0]} />
+    const matchedChannel = Object.entries(state.channels).find(entry => {
+      const [ , attrs ] = entry;
+      return attrs.name === node.getName()
+    });
+    return matchedChannel && matchedChannel.length ? <Channel channel={matchedChannel[0]} /> : null
   };
 
   modelChanged = () => {
@@ -137,7 +140,12 @@ class ChannelTabsContainer extends Component {
 
     if (_.isEmpty(state.channels)) return;
 
-    channel = Object.entries(state.channels).find(entry => entry[1].name === node.getName())[1];
+    const matchedChannel = Object.entries(state.channels).find(entry => {
+      const [ , attrs ] = entry;
+      return attrs.name === node.getName()
+    });
+
+    channel = matchedChannel && matchedChannel.length > 1 ? matchedChannel[1] : {};
 
     if (channel.unreadMessageCount === 0) {
       setUnreadClassName('');

--- a/packages/client/src/Views/ChannelTabsContainer.jsx
+++ b/packages/client/src/Views/ChannelTabsContainer.jsx
@@ -26,6 +26,13 @@ const json = {
 class ChannelTabsContainer extends Component {
   static contextType = PlayerStateContext;
 
+  static findChannelByName = (channels, name) => {
+    Object.entries(channels).find(entry => {
+      const [ , attrs ] = entry;
+      return attrs.name === name
+    });
+  }
+
   constructor(props, context) {
     super(props);
     const [ state, dispatch ] = context;
@@ -114,10 +121,7 @@ class ChannelTabsContainer extends Component {
   factory = (node) => {
     const [ state ] = this.context;
     if (_.isEmpty(state.channels)) return;
-    const matchedChannel = Object.entries(state.channels).find(entry => {
-      const [ , attrs ] = entry;
-      return attrs.name === node.getName()
-    });
+    const matchedChannel = ChannelTabsContainer.findChannelByName(state.channels, node.getName());
     return matchedChannel && matchedChannel.length ? <Channel channel={matchedChannel[0]} /> : null
   };
 
@@ -140,10 +144,7 @@ class ChannelTabsContainer extends Component {
 
     if (_.isEmpty(state.channels)) return;
 
-    const matchedChannel = Object.entries(state.channels).find(entry => {
-      const [ , attrs ] = entry;
-      return attrs.name === node.getName()
-    });
+    const matchedChannel = ChannelTabsContainer.findChannelByName(state.channels, node.getName());
 
     channel = matchedChannel && matchedChannel.length > 1 ? matchedChannel[1] : {};
 

--- a/packages/client/src/Views/ChannelTabsContainer.jsx
+++ b/packages/client/src/Views/ChannelTabsContainer.jsx
@@ -27,7 +27,7 @@ class ChannelTabsContainer extends Component {
   static contextType = PlayerStateContext;
 
   static findChannelByName = (channels, name) => {
-    Object.entries(channels).find(entry => {
+    return Object.entries(channels).find(entry => {
       const [ , attrs ] = entry;
       return attrs.name === name
     });


### PR DESCRIPTION
## 🧰 Ticket
Closes #48 
Closes #33

## 🚀 Overview: 
Add conditional checks on current updated channel's tab

## 🤔 Reason: 
The issue can reliably be repeated by putting a player into a channel, with some message types.
Then, remove that row from the Channel editor. When you click on SAVE CHANNEL the Player UI crashes.

## 🔨Work carried out:
- [x] Add conditional checks on channel updates
- [x] Tests pass
[Possible to crash UI with inconsistent tabs](https://app.gitkraken.com/glo/board/XZIuhoko5QAPaF0f/card/XclxUMhm9wAPZ9b-)