### PR TITLE
Introduce regexp matcher for file URLs

### DIFF
--- a/packages/client/src/Helpers/isValidUrl.js
+++ b/packages/client/src/Helpers/isValidUrl.js
@@ -1,9 +1,12 @@
 export default function (str) {
-  var pattern = new RegExp('^(https?:\\/\\/)?' + // protocol
+  var httpPattern = new RegExp('^(https?:\\/\\/)?' + // protocol
     '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
     '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
     '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
     '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
     '(\\#[-a-z\\d_]*)?$', 'i') // fragment locator
-  return !!pattern.test(str)
+  var filePattern = new RegExp('^(file:\\/\\/)?' + // protocol
+    '(\\?[;&a-z\\d%_.~+=-]*)?') // query string
+
+  return !!httpPattern.test(str) || !!filePattern.test(str)
 }


### PR DESCRIPTION
## 🧰 Ticket
Fixes #52 

## 🚀 Overview: 
Allow file URLs to be clickable in Link messages.

## 🤔 Reason: 
Next week's game designer wishes to be able to distribute FILE urls.

## 🔨Work carried out:
Add a second regexp, that verifies 

- [x] Tests pass

## 🖥️ Screenshot
Before:
![image](https://user-images.githubusercontent.com/1108513/68993462-6a3d8f00-0870-11ea-968c-85a6812d5473.png)

After:
![image](https://user-images.githubusercontent.com/1108513/68993475-788bab00-0870-11ea-9602-3a92de65f736.png)


## 📝 Developer Notes:
It may have been more efficient to generate a combined RegExp, but I couldn't find an existing one to use.
