### PR TITLE
Simplify the file:// test, 

### DIFF
--- a/packages/client/src/Helpers/isValidUrl.js
+++ b/packages/client/src/Helpers/isValidUrl.js
@@ -5,8 +5,7 @@ export default function (str) {
     '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
     '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
     '(\\#[-a-z\\d_]*)?$', 'i') // fragment locator
-  var filePattern = new RegExp('^(file:\\/\\/)?' + // protocol
-    '(\\?[;&a-z\\d%_.~+=-]*)?') // query string
+  var windowsFilePath = new RegExp('^[\\w\\\\.:\\s]+?\\.\\w{2,4}')
 
-  return !!httpPattern.test(str) || !!filePattern.test(str)
+  return !!httpPattern.test(str) || str.startsWith('file:///') || !!windowsFilePath.test(str)
 }


### PR DESCRIPTION

## 🧰 Ticket
Fixes earlier PR for #52 

The file:// regexp was too relaxed, it interpreted all text as a URL so all fields were mistakenly made clickable.

## 🚀 Overview: 
The `file://` has been simplified, and a new test inserted that allows a plain MS-Windows URL, like `c:\tmp\sample.txt`

## 🔨Work carried out:
* swap `file://` regexp for simple `startsWith()`
* introduce new regexp for MS-windows file

## 🖥️ Screenshot
[If the work is UI related then paste a screenshot of the update here.]
![image](https://user-images.githubusercontent.com/1108513/68996336-8a7d4600-0890-11ea-9414-068e0915eec6.png)

