### PR TITLE
try using "/" to force connection to current server

### DIFF
--- a/packages/client/.env
+++ b/packages/client/.env
@@ -4,4 +4,4 @@ REACT_APP_VERSION=$npm_package_version
 REACT_APP_NAME=$npm_package_name
 # uncomment the next line to connect Serge to a server other than the one this
 # page was served from
-REACT_APP_SERVER_PATH='/'
+# REACT_APP_SERVER_PATH='/'

--- a/packages/client/.env
+++ b/packages/client/.env
@@ -4,4 +4,4 @@ REACT_APP_VERSION=$npm_package_version
 REACT_APP_NAME=$npm_package_name
 # uncomment the next line to connect Serge to a server other than the one this
 # page was served from
-#REACT_APP_SERVER_PATH='https://serge-dev.herokuapp.com/'
+REACT_APP_SERVER_PATH='/'


### PR DESCRIPTION
## 🚀 Overview: 
@lilitkarapetyan has explained that we could use "/" as the REACT_APP_SERVER_PATH to force a connection to the current host.

This PR tests that suggestion.

## 🔗 Link to preview
[If you're on a project which auto-deploys branches, link to the branches preview link here]

## 🤔 Reason: 
Lilit's strategy is almost certainly better than Ian's.

## 🔨Work carried out:
Just trying "/" as REACT_APP_SERVER_PATH

## 🖥️ Screenshot
[If the work is UI related then paste a screenshot of the update here.]
