### PR TITLE
Use correct API for access code

### DIFF
--- a/packages/e2e/cypress/integration/walkThroughTestcases/walkthrought.spec.js
+++ b/packages/e2e/cypress/integration/walkThroughTestcases/walkthrought.spec.js
@@ -20,7 +20,7 @@ describe('Run_automation_test_Serge', function () {
       //Overview   
       user.createNewGame()
         .inputRoomName(roomName)
-        .clickShowAccessCode('on')
+        .clickShowAccessCode()
         .clickSaveOverview()
 
       //Forces


### PR DESCRIPTION
## 🚀 Overview: 
Fix for intermittent e2e testing bug

## 🔗 Link to preview
Successful run-through here:
https://dashboard.cypress.io/#/projects/rinvt1/runs/83/specs

## 🤔 Reason: 
We had an intermitted test failure with Cypress.  The Cypress dev spotted the fact that the "Show access codes" checkbox wasn't getting ticked.

## 🔨Work carried out:
Correctly utilise the E2E api for our app

- [x] Tests pass

## 📝 Developer Notes:
Since the problem was intermittent, we _may_ not have fixed it.  But, we spotted that the e2d API or Serge wasn't being followed, and after fixing the call to `.clickShowAccessCode()` it worked fine.