### PR TITLE
include twin_pane interface

### DIFF
--- a/packages/client/public/clock.html
+++ b/packages/client/public/clock.html
@@ -1,0 +1,4 @@
+<meta http-equiv="refresh" content="1">
+<html>
+    <body>12:45:23 RUNNING</body>
+</html>

--- a/packages/client/public/twin_pane.html
+++ b/packages/client/public/twin_pane.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+    <FRAMESET ROWS="10%,90%">
+        <FRAME SRC="http://www.clocktab.com/" NAME="frm1" ID="frm1">
+        <FRAME SRC="/serge/player" NAME="frm2" ID="frm2">
+    </FRAMESET>
+</html>

--- a/packages/client/public/twin_pane.html
+++ b/packages/client/public/twin_pane.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
-    <FRAMESET ROWS="10%,90%">
-        <FRAME SRC="http://www.clocktab.com/" NAME="frm1" ID="frm1">
+    <FRAMESET ROWS="5%,95%">
+        <FRAME SRC="http://192.168.1.111:8000/clock.html" NAME="frm1" ID="frm1">
         <FRAME SRC="/serge/player" NAME="frm2" ID="frm2">
     </FRAMESET>
 </html>

--- a/packages/client/public/twin_pane.html
+++ b/packages/client/public/twin_pane.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <FRAMESET ROWS="5%,95%">
-        <FRAME SRC="http://192.168.1.111:8000/clock.html" NAME="frm1" ID="frm1">
+        <FRAME SRC="http://www.clocktab.com/" NAME="frm1" ID="frm1">
         <FRAME SRC="/serge/player" NAME="frm2" ID="frm2">
     </FRAMESET>
 </html>


### PR DESCRIPTION
## 🚀 Overview: 
Workaround to support customer who is running their own clock for a wargame.

## 🔗 Link to preview
[If you're on a project which auto-deploys branches, link to the branches preview link here]

## 🤔 Reason: 
Use iFrame to let them display their own auto-updating clock at the top of the Serge screen.

## 🔨Work carried out:
Research iFrames & self-updating meta-refresh pages

- [x] Tests pass
N/A

## 🖥️ Screenshot
![image](https://user-images.githubusercontent.com/1108513/69257480-063e0200-0bb3-11ea-8e00-ed0d790b4870.png)

## 📝 Developer Notes:
We can probably drop this functionality in the medium term. But, it does demonstrate the requirement to be able to run an external clock - probably by us pinging a micro-service.