### PR TITLE
Introduce batch file to allow Serge to be started without command line

### DIFF
--- a/Serge.bat
+++ b/Serge.bat
@@ -1,0 +1,1 @@
+yarn serge


### PR DESCRIPTION
## 🚀 Overview: 
Now that users don't need to reconfigure the `.env` variable, MS-Windows users could just run serge from a batch-file script, including putting a shortcut to it on their desktop.

## 🔨Work carried out:
Just create `serge.bat` which calls `yarn serge`

- [x] Tests pass
N/A 

## 📝 Developer Notes:
The requirement for this should go away as we move to `serge-win.exe`