### PR TITLE
E2e fix show access clicking problem

### DIFF
--- a/packages/e2e/cypress/support/pageAction/adminAction.js
+++ b/packages/e2e/cypress/support/pageAction/adminAction.js
@@ -51,10 +51,6 @@ Cypress.Commands.add("clickSaveOverview", () => {
 let numberRun = 0
 export function checkAccessCodeCheckbox() {
   numberRun++
-  cy.get('input#show-access-codes')
-  .check({
-    force: true
-  })
   cy.wait(500);
   cy.get('input#show-access-codes').invoke('prop', 'checked').then($isChecked => {
     ($isChecked === true || numberRun > 5) ? cy.log('done') : checkAccessCode();

--- a/packages/e2e/cypress/support/pageAction/adminAction.js
+++ b/packages/e2e/cypress/support/pageAction/adminAction.js
@@ -51,9 +51,10 @@ Cypress.Commands.add("clickSaveOverview", () => {
 Cypress.Commands.add("clickShowAccessCode", () => {
   cy.wait(500)
   cy.get('input#show-access-codes')
-    .check({
+    .click({
       force: true
-    })
+    }).should('be.checked')
+  cy.wait(500)
 })
 
 Cypress.Commands.add("inputRoleName", (roleName) => {

--- a/packages/e2e/cypress/support/pageAction/adminAction.js
+++ b/packages/e2e/cypress/support/pageAction/adminAction.js
@@ -51,6 +51,10 @@ Cypress.Commands.add("clickSaveOverview", () => {
 let numberRun = 0
 export function checkAccessCodeCheckbox() {
   numberRun++
+  cy.get('input#show-access-codes')
+  .check({
+    force: true
+  })
   cy.wait(500);
   cy.get('input#show-access-codes').invoke('prop', 'checked').then($isChecked => {
     ($isChecked === true || numberRun > 5) ? cy.log('done') : checkAccessCodeCheckbox();

--- a/packages/e2e/cypress/support/pageAction/adminAction.js
+++ b/packages/e2e/cypress/support/pageAction/adminAction.js
@@ -53,7 +53,7 @@ export function checkAccessCodeCheckbox() {
   numberRun++
   cy.wait(500);
   cy.get('input#show-access-codes').invoke('prop', 'checked').then($isChecked => {
-    ($isChecked === true || numberRun > 5) ? cy.log('done') : checkAccessCode();
+    ($isChecked === true || numberRun > 5) ? cy.log('done') : checkAccessCodeCheckbox();
   })
   cy.get('input#show-access-codes').should('be.checked');
 }

--- a/packages/e2e/cypress/support/pageAction/adminAction.js
+++ b/packages/e2e/cypress/support/pageAction/adminAction.js
@@ -48,13 +48,22 @@ Cypress.Commands.add("clickSaveOverview", () => {
     .click()
 })
 
-Cypress.Commands.add("clickShowAccessCode", () => {
-  cy.wait(500)
+let numberRun = 0
+export function checkAccessCodeCheckbox() {
+  numberRun++
   cy.get('input#show-access-codes')
-    .click({
-      force: true
-    }).should('be.checked')
-  cy.wait(500)
+  .check({
+    force: true
+  })
+  cy.wait(500);
+  cy.get('input#show-access-codes').invoke('prop', 'checked').then($isChecked => {
+    ($isChecked === true || numberRun > 5) ? cy.log('done') : checkAccessCode();
+  })
+  cy.get('input#show-access-codes').should('be.checked');
+}
+
+Cypress.Commands.add("clickShowAccessCode", () => {
+  checkAccessCodeCheckbox()
 })
 
 Cypress.Commands.add("inputRoleName", (roleName) => {


### PR DESCRIPTION
It was that the state of checkbox refreshed after clicking, it is weird but might because we have another React event there

so what I did is to repeat the action click for several time (5 times) if it is not working then it is an error, but if it works, it will be sure to be checked