### PR TITLE
Fix undefined object destructure

### DIFF
--- a/packages/client/src/ActionsAndReducers/playerUi/playerUi_Reducer.js
+++ b/packages/client/src/ActionsAndReducers/playerUi/playerUi_Reducer.js
@@ -54,13 +54,9 @@ export const playerUiReducer = (state = initialState, action) => {
     return matchedForce(p, selectedForce) && p.roles.length === 0
   }
   const checkParticipantStates = (channel, newState) => {
-
     const participatingRole = channel.participants.find(p => matchedForceAndRole(p, newState))
-    
-    // Ian commented out these lines, since we were causing
-    // runtime error when trying to unpack a composite return object
-    //   const participatingForce = channel.participants.find(p => matchedForce(p, newState.selectedForce))
-    // if (!participatingForce && !newState.isObserver) return
+    const participatingForce = channel.participants.find(p => matchedForce(p, newState.selectedForce))
+    if (!participatingForce && !newState.isObserver) return {}
 
     const isParticipant = !!participatingRole
     const allRolesIncluded = channel.participants.find(p => matchedAllRoles(p, newState.selectedForce))


### PR DESCRIPTION
## 🧰 Ticket
Closes #73 

## 🚀 Overview: 
Add default empty object return for participant states.

## 🤔 Reason: 
Fixes on #66 introduced new bug where non-participating player screen crashed when consuming on other player updates.

Upon checking by @IanMayo , it showed that there's a de-structuring failure at playerUI_reducer line 75.

## 🔨Work carried out:
- [x] Default empty object added for `checkParticipantStates` method.
- [x] Tests pass
[Non-participating player failed to get templates](https://app.gitkraken.com/glo/board/XZIuhoko5QAPaF0f/card/XdhrOs7rhgAPLtcb)