### PR TITLE
Update welcome screen

### DIFF
--- a/packages/client/src/Components/Router/RouterMain.jsx
+++ b/packages/client/src/Components/Router/RouterMain.jsx
@@ -28,7 +28,7 @@ class RouterMain extends Component {
 
   componentDidMount () {
     this.setState({
-      currentView: components[this.path]
+      currentView: components[this.path] || components[PLAYERUI_ROUTE]
     })
   }
 

--- a/packages/client/src/Views/PlayerUiLandingScreen.jsx
+++ b/packages/client/src/Views/PlayerUiLandingScreen.jsx
@@ -1,16 +1,22 @@
 import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import lineBreak from '../Helpers/splitNewLineBreak'
+import { ADMIN_ROUTE } from '../consts'
+import { faTools } from '@fortawesome/free-solid-svg-icons'
 
 export default function PlayerUiLandingScreen ({ gameInfo, enterSerge }) {
   return (
     <div className="flex-content-wrapper flex-content-wrapper--welcome">
       <div className="flex-content flex-content--welcome">
-        <div className="flex-content--center contain-welcome-screen">
+        <div className="flex-content--center contain-welcome-screen position-relative">
           <div className="welcome-logo">
             {
               gameInfo.imageUrlSet ? <img className="serge-logo" src={gameInfo.imageUrl} alt="Serge gaming" /> : null
             }
           </div>
+          <a href={ADMIN_ROUTE} className="link-admin">
+            <FontAwesomeIcon icon={faTools} />
+          </a>
           <div className="welcome-desc">
             <h1>{gameInfo.title}</h1>
             {lineBreak(gameInfo.description)}

--- a/packages/themes/_playerUi.scss
+++ b/packages/themes/_playerUi.scss
@@ -723,3 +723,14 @@
     right: 0;
   }
 }
+
+.link-admin {
+  position: absolute;
+  top: 0;
+  right: 0;
+  color: white;
+
+  &:hover {
+    color: white;
+  }
+}


### PR DESCRIPTION
## 🧰 Ticket
Closes #56 

## 🚀 Overview: 
Update default landing screen view and add admin link

## 🤔 Reason: 
Our original UI design had a link to the admin page from the player page:
https://xd.adobe.com/view/d7896f40-3024-4414-7d45-1bd097e3b534-a1b8/
So, at the top-right of the player welcome page we should have a link to the admin page.
Further to that, we should serve the player page as the default page.
We shouldn't have to navigate to server:8080/serge/player - the player page should be served from serge:8080

## 🔨Work carried out:
- [x] Add default view in the router
- [x] Add admin link in the welcome screen
- [x] Tests pass
[Welcome experience](https://app.gitkraken.com/glo/board/XZIuhoko5QAPaF0f/card/XdBDvM7rhgAPLh0o)