### PR TITLE
remove limit on serge logo size

### DIFF
--- a/packages/themes/demo.scss
+++ b/packages/themes/demo.scss
@@ -143,10 +143,6 @@
       width: 90%;
     }
 
-    .serge-logo {
-      width: 100px;
-    }
-
     .welcome-desc {
       h1 {
         font-size: 1.5rem;


### PR DESCRIPTION
## 🚀 Overview: 
Remove limit on Serge icon size.

## 🤔 Reason: 
In the player UI the size of the Serge logo was restricted to 100Px. This size limit was present in the CSS for the demo UI, but the CSS setting was _leaking_ through to the main player UI.

This is a temporary fix, to support the current wargame.

## 🔨Work carried out:

Deleted a couple of lines of CSS.

