### PR TITLE
Feature/118 mouse performance

### DIFF
--- a/packages/client/src/Helpers/MovementListener.js
+++ b/packages/client/src/Helpers/MovementListener.js
@@ -114,54 +114,57 @@ export default class MovementListener {
           this.planningLine.setLatLngs([this.startHex.centrePos, cursorLoc])
         }
 
-        // are we in a safe cell
+        // find cell under cursor
         const curCell = this.grid.cellFor(cursorLoc)
 
-        // is this an achievable cell?
-        if (this.achievableCells.includes(curCell)) {
-          // ok, remember it
-          this.lastHex = curCell
-        }
-
-        // clear the old cells
-        this.routeHexes.forEach(cell => {
-          if (this.achievableCells.includes(cell)) {
-            cell.polygon.setStyle(rangeStyle)
-          } else {
-            cell.polygon.setStyle(defaultHexStyle)
+        // see if this cell is different to the previous one?
+        if (!curCell.equals(this.lastHex)) {
+          // is this an achievable cell?
+          if (this.achievableCells.includes(curCell)) {
+            // ok, remember it
+            this.lastHex = curCell
           }
-        })
 
-        console.log(this.startHex)
-
-        // get the route
-        let newRoute = this.grid.hexesBetween(this.startHex, this.lastHex)
-
-        // if we have a restricted possible region,
-        // trim to it
-        if (this.achievableCells) {
-          newRoute = newRoute.filter(cell => this.achievableCells.includes(cell))
-        }
-
-        // and generate new cells
-        this.routeLats = []
-        this.routeHexes = newRoute
-        if (marker.mobile) {
+          // clear the old cells
           this.routeHexes.forEach(cell => {
-            cell.polygon.setStyle(routeStyle)
-            this.routeLats.push(cell.centrePos)
+            if (this.achievableCells.includes(cell)) {
+              cell.polygon.setStyle(rangeStyle)
+            } else {
+              cell.polygon.setStyle(defaultHexStyle)
+            }
           })
-        } else {
-          // insert the current location twice,
-          // to give us a point marker
-          if (this.lastHex) {
-            this.routeLats.push(this.lastHex.centrePos)
-            this.routeLats.push(this.lastHex.centrePos)
-          }
-        }
 
-        if (this.routeLats.length > 1) {
-          this.planningLine.setLatLngs(this.routeLats)
+          console.log(this.startHex)
+
+          // get the route
+          let newRoute = this.grid.hexesBetween(this.startHex, this.lastHex)
+
+          // if we have a restricted possible region,
+          // trim to it
+          if (this.achievableCells) {
+            newRoute = newRoute.filter(cell => this.achievableCells.includes(cell))
+          }
+
+          // and generate new cells
+          this.routeLats = []
+          this.routeHexes = newRoute
+          if (marker.mobile) {
+            this.routeHexes.forEach(cell => {
+              cell.polygon.setStyle(routeStyle)
+              this.routeLats.push(cell.centrePos)
+            })
+          } else {
+            // insert the current location twice,
+            // to give us a point marker
+            if (this.lastHex) {
+              this.routeLats.push(this.lastHex.centrePos)
+              this.routeLats.push(this.lastHex.centrePos)
+            }
+          }
+
+          if (this.routeLats.length > 1) {
+            this.planningLine.setLatLngs(this.routeLats)
+          }
         }
       }
     })

--- a/packages/client/src/Helpers/MovementListener.js
+++ b/packages/client/src/Helpers/MovementListener.js
@@ -133,8 +133,6 @@ export default class MovementListener {
               }
             })
 
-            console.log(this.startHex)
-
             // get the route
             let newRoute = this.grid.hexesBetween(this.startHex, this.lastHex)
 

--- a/packages/client/src/Helpers/MovementListener.js
+++ b/packages/client/src/Helpers/MovementListener.js
@@ -117,53 +117,53 @@ export default class MovementListener {
         // find cell under cursor
         const curCell = this.grid.cellFor(cursorLoc)
 
-        // see if this cell is different to the previous one?
-        if (!curCell.equals(this.lastHex)) {
+        // see if a cell is obtained, and that it's different to the previous one?
+        if (!((typeof curCell === 'undefined') || (curCell.equals(this.lastHex)))) {
           // is this an achievable cell?
           if (this.achievableCells.includes(curCell)) {
             // ok, remember it
             this.lastHex = curCell
-          }
 
-          // clear the old cells
-          this.routeHexes.forEach(cell => {
-            if (this.achievableCells.includes(cell)) {
-              cell.polygon.setStyle(rangeStyle)
-            } else {
-              cell.polygon.setStyle(defaultHexStyle)
-            }
-          })
-
-          console.log(this.startHex)
-
-          // get the route
-          let newRoute = this.grid.hexesBetween(this.startHex, this.lastHex)
-
-          // if we have a restricted possible region,
-          // trim to it
-          if (this.achievableCells) {
-            newRoute = newRoute.filter(cell => this.achievableCells.includes(cell))
-          }
-
-          // and generate new cells
-          this.routeLats = []
-          this.routeHexes = newRoute
-          if (marker.mobile) {
+            // clear the old cells
             this.routeHexes.forEach(cell => {
-              cell.polygon.setStyle(routeStyle)
-              this.routeLats.push(cell.centrePos)
+              if (this.achievableCells.includes(cell)) {
+                cell.polygon.setStyle(rangeStyle)
+              } else {
+                cell.polygon.setStyle(defaultHexStyle)
+              }
             })
-          } else {
-            // insert the current location twice,
-            // to give us a point marker
-            if (this.lastHex) {
-              this.routeLats.push(this.lastHex.centrePos)
-              this.routeLats.push(this.lastHex.centrePos)
-            }
-          }
 
-          if (this.routeLats.length > 1) {
-            this.planningLine.setLatLngs(this.routeLats)
+            console.log(this.startHex)
+
+            // get the route
+            let newRoute = this.grid.hexesBetween(this.startHex, this.lastHex)
+
+            // if we have a restricted possible region,
+            // trim to it
+            if (this.achievableCells) {
+              newRoute = newRoute.filter(cell => this.achievableCells.includes(cell))
+            }
+
+            // and generate new cells
+            this.routeLats = []
+            this.routeHexes = newRoute
+            if (marker.mobile) {
+              this.routeHexes.forEach(cell => {
+                cell.polygon.setStyle(routeStyle)
+                this.routeLats.push(cell.centrePos)
+              })
+            } else {
+              // insert the current location twice,
+              // to give us a point marker
+              if (this.lastHex) {
+                this.routeLats.push(this.lastHex.centrePos)
+                this.routeLats.push(this.lastHex.centrePos)
+              }
+            }
+
+            if (this.routeLats.length > 1) {
+              this.planningLine.setLatLngs(this.routeLats)
+            }
           }
         }
       }


### PR DESCRIPTION
## 🧰 Ticket
Closes #118 

## 🚀 Overview: 
Reduce number of times we produce list of cells between two locations, and also reduce the number of Leaflet redraws.

## 🔗 Link to preview
[If you're on a project which auto-deploys branches, link to the branches preview link here]

## 🤔 Reason: 
Console logging showed that code to calculate possible routes was being called too often.

## 🔨Work carried out:
Introduce two sets of `if` constructs to test if we should bother recalculating route.

- [x] Tests pass

[Optimise routing hexes](https://app.gitkraken.com/glo/board/XZIuhoko5QAPaF0f/card/Xg9ahiNdWgAQmf_I)