### PR TITLE
138. Map autoupdate based on forces

### DIFF
--- a/packages/client/src/Components/Mapping/index.jsx
+++ b/packages/client/src/Components/Mapping/index.jsx
@@ -4,6 +4,7 @@ import GridImplementation from '../../Helpers/GridImplementation'
 import MapAdjudicatingUmpireListener from '../../Helpers/MapAdjudicatingUmpireListener'
 import MapAdjudicatingPlayerListener from '../../Helpers/MapAdjudicatingPlayerListener'
 import MapAdjudicationPendingListener from '../../Helpers/MapAdjudicationPendingListener'
+import MapMarkersControl from '../../Helpers/MapMarkersControl'
 import MapPlanningPlayerListener from '../../Helpers/MapPlanningPlayerListener'
 import MapPlanningUmpireListener from '../../Helpers/MapPlanningUmpireListener'
 import markerFor from '../../Helpers/markerFor'
@@ -96,7 +97,7 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
     return () => console.log('Map unmounted')
   }, [])
 
-  const sendMessage = (mType, values) => {
+  const sendMessage = (mType, message) => {
     const curForce = allForces.find((force) => force.uniqid === selectedForce)
     const details = {
       channel: channelID,
@@ -110,7 +111,7 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
       messageType: mType,
       timestamp: new Date().toISOString()
     }
-    saveMapMessage(currentWargame, details, values)
+    saveMapMessage(currentWargame, details, message)
   }
 
   /** callback function - will transmit received parameters as "laydown" action */
@@ -211,7 +212,13 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
     })
   }, [forcesRef, phaseRef, currentTurnRef])
 
-  return (<div id="map" className="mapping"></div>)
+  useEffect(() => {
+    MapMarkersControl(platformsLayerRef.current, gridImplRef.current, allForces)
+  }, [allForces])
+
+  return (
+    <div id="map" className="mapping"/>
+  )
 }
 
 export default Mapping

--- a/packages/client/src/Helpers/MapMarkersControl.js
+++ b/packages/client/src/Helpers/MapMarkersControl.js
@@ -1,0 +1,18 @@
+const MapMarkersControl = (markers, grid, allForces) => {
+  markers.eachLayer(function (marker) {
+    const force = allForces.find(force => marker.force === force.name)
+    if (force && marker.asset) {
+      const asset = force.assets.find(({ name }) => name === marker.asset.name)
+      if (asset) {
+        if (marker.asset.position !== asset.position) {
+          // update marker
+          marker.setLatLng(grid.hexNamed(asset.position).centrePos)
+        }
+      } else {
+        // asset not found
+      }
+    }
+  })
+}
+
+export default MapMarkersControl

--- a/packages/client/src/api/wargames_api.js
+++ b/packages/client/src/api/wargames_api.js
@@ -811,21 +811,14 @@ export const postNewMessage = (dbName, details, message) => {
 // Copied from postNewMessage cgange and add new logic for Mapping
 // console logs will not works there
 export const postNewMapMessage = (dbName, details, message) => {
-  console.log('postNewMapMessage');
   const db = wargameDbStore.find((db) => db.name === dbName).db
-  return new Promise((resolve, reject) => {
-    db.put({
-      _id: new Date().toISOString(),
-      details,
-      message
-    })
-      .then((res) => {
-        resolve(res)
-      })
-      .catch((err) => {
-        console.log(err)
-        reject(err)
-      })
+  db.put({
+    _id: new Date().toISOString(),
+    details,
+    message
+  }).catch((err) => {
+    console.log(err)
+    return err
   })
 }
 


### PR DESCRIPTION
## 🧰 Ticket
Fixes #138 

## 🚀 Overview: 
This PR proves the message flow for updating the map on receipt of particular types of message.

It also provides a model for defining executable blocks of code that update on React changes.

## 🔗 Link to preview
https://serge-review-feature-91-efwsfv.herokuapp.com/

## Steps to reproduce:
* open two tabs, one as White, one as Red
* Both login to `MWARC Initialised`
* Here in Turn Zero, Adjudication Phase, Red is able to choose where his assets are (Force Laydown)
* When Red positions his assets, the asset will also move on the White player's map