### PR TITLE
[serge-168] Add dynamic serverPath based on base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,22 @@ In your command line, navigate to the project and then run the following command
 
 This will start the full application in 'demo' mode, you can see the application in action by visiting: [http://localhost:8080](http://localhost:8080).
 
-For front-end developers relying on live rebuilds, they should first follow the above steps, and note the IP address & Port provided by the server script.  Then the `packages\client\.env` file should be mofidied, by using the server address for `REACT_APP_SERVER_PATH`.  The `https` should probably also be modified to `http`, too.
+For front-end developers relying on live rebuilds, they should first follow the above steps, and note the IP address & Port provided by the server script. Note: leave that Serge process running.
 
-Once the above configuration has happened, the client app can be started with
 
 ```base
   yarn start:client
 ```
 
+This will start the front-end server.  The development environment will start up, and after a few seconds the browser page will open at something like `localhost:3000`.  The IP address for the backend server should be appended to this, so the URL looks like: `http://localhost:3000/?host=http://192.168.1.115:8080`. 
+
+## Quick access to games & roles
+
+Again for developers, there are convenient ways of going directly into a particular wargame, registered as a particular user. This is through the user of the `wargame` and `access` URL parameters, like this:
+
+```base
+http://localhost:3000/?wargame=wargame-k5kw38gf&access=p5543
+```
 
 ## Monorepo & package management
 

--- a/packages/client/src/Views/PlayerUiLobby.jsx
+++ b/packages/client/src/Views/PlayerUiLobby.jsx
@@ -3,13 +3,21 @@ import Select from 'react-select'
 import TextInput from '../Components/Inputs/TextInput'
 import { useStateValue } from '../Store/PlayerUi'
 import { getWargame } from '../ActionsAndReducers/playerUi/playerUi_ActionCreators'
+import { serverPath } from '../consts'
 
 export default function PlayerUiLobby ({ wargameList, roleOptions, checkPassword }) {
   if (!wargameList) {
     return (
       <div className="flex-content-wrapper flex-content-wrapper--welcome">
-        <div className="flex-content flex-content--welcome">      
-          <h3>Server Not Found = check configuration</h3>
+        <div className="flex-content flex-content--welcome">
+          <h2>Serge - Serious Gaming Evolved</h2>
+          <h2>&nbsp;</h2>
+          <h3>* Server Not Found - check configuration</h3>
+          <h3>* Trying to connect to: <i>{serverPath}</i></h3>
+          <h3>* The above URL should be something like:</h3>
+          <h4>&nbsp;&nbsp;&nbsp;- Dev machine: http://192.168.1.115:8080></h4>
+          <h4>&nbsp;&nbsp;&nbsp;- Dedicated network:  http://serge:8080</h4>
+          <h4>&nbsp;&nbsp;&nbsp;- Online review: https://serge-review.herokuapp.com/</h4>
         </div>
       </div>
     )

--- a/packages/client/src/Views/PlayerUiLobby.jsx
+++ b/packages/client/src/Views/PlayerUiLobby.jsx
@@ -5,6 +5,15 @@ import { useStateValue } from '../Store/PlayerUi'
 import { getWargame } from '../ActionsAndReducers/playerUi/playerUi_ActionCreators'
 
 export default function PlayerUiLobby ({ wargameList, roleOptions, checkPassword }) {
+  if (!wargameList) {
+    return (
+      <div className="flex-content-wrapper flex-content-wrapper--welcome">
+        <div className="flex-content flex-content--welcome">      
+          <h3>Server Not Found = check configuration</h3>
+        </div>
+      </div>
+    )
+  }
   const [localState, setState] = useReducer(
     (state, newState) => ({ ...state, ...newState }),
     {

--- a/packages/client/src/consts.js
+++ b/packages/client/src/consts.js
@@ -2,24 +2,6 @@ import uniqId from 'uniqid'
 import moment from 'moment'
 import ExpiredStorage from 'expired-storage'
 
-// Nov 2019. Ian modified the server path to use the
-// current URL, so we can use Heroku to provide
-// review instances of the app.  In these
-// review instances, we can't predict the URL, so
-// were failing CORS test
-export const serverPath = (
-  window.G_CONFIG.REACT_APP_SERVER_PATH || process.env.REACT_APP_SERVER_PATH || window.location.origin + '/'
-).replace(/\/?$/, '/')
-
-// export const serverPath = 'http://localhost:8080/';
-/*
-for development just create .env.local file in client folder and add line,
-it's under gitignore and you don't need change this value before every deployment:
-REACT_APP_SERVER_PATH='http://localhost:8080/'
-*/
-
-export const databasePath = `${serverPath}db/`
-
 export const DEFAULT_SERVER = 'Nelson'
 export const DEFAULT_PORT = '8080'
 
@@ -58,6 +40,28 @@ export const UMPIRE_FORCE = 'umpire'
 // series of constants used for `messageType` when sending map events
 export const FORCE_LAYDOWN = 'ForceLaydown'
 export const VISIBILIY_CHANGES = 'VisibilityChanges'
+
+// Nov 2019. Ian modified the server path to use the
+// current URL, so we can use Heroku to provide
+// review instances of the app.  In these
+// review instances, we can't predict the URL, so
+// were failing CORS test
+export const baseUrl = () => {
+  const { hostname, protocol } = window.location
+  return `${protocol}//${hostname}${DEFAULT_PORT ? `:${DEFAULT_PORT}` : ''}`
+}
+export const serverPath = (
+  window.G_CONFIG.REACT_APP_SERVER_PATH || process.env.REACT_APP_SERVER_PATH || baseUrl() + '/'
+).replace(/\/?$/, '/')
+
+// export const serverPath = 'http://localhost:8080/';
+/*
+for development just create .env.local file in client folder and add line,
+it's under gitignore and you don't need change this value before every deployment:
+REACT_APP_SERVER_PATH='http://localhost:8080/'
+*/
+
+export const databasePath = `${serverPath}db/`
 
 export const headers = {
   'Content-Type': 'application/json',

--- a/packages/client/src/consts.js
+++ b/packages/client/src/consts.js
@@ -48,7 +48,8 @@ export const VISIBILIY_CHANGES = 'VisibilityChanges'
 // were failing CORS test
 export const baseUrl = () => {
   const { hostname, protocol } = window.location
-  return `${protocol}//${hostname}${DEFAULT_PORT ? `:${DEFAULT_PORT}` : ''}`
+  const host = (new URL(window.location)).searchParams.get('host')
+  return host ? host : `${protocol}//${hostname}${DEFAULT_PORT ? `:${DEFAULT_PORT}` : ''}`
 }
 export const serverPath = (
   window.G_CONFIG.REACT_APP_SERVER_PATH || process.env.REACT_APP_SERVER_PATH || baseUrl() + '/'


### PR DESCRIPTION
## 🧰 Ticket
Closes #168 

## 🚀 Overview: 
Refactor `host` with base URL instead of origin

Example of URL:
![image](https://user-images.githubusercontent.com/1108513/72742822-6e549880-3ba2-11ea-9454-33f35b91b6f3.png)


## 🤔 Reason: 
The front-end currently falls over if we are unable to connect to the server. Aah, the backend will, too.
When this happens, we should fail gracefully, and show a page explaining that Serge cannot see the server.

## 🔨Work carried out:

- [x] Refactor serverPath with base url value
- [x] Tests pass

## 📝 Developer Notes:
Front end should now read from either its base URL or from `?host` URL parameter