### PR TITLE
Hotfix/render player interface

### DIFF
--- a/packages/client/src/ActionsAndReducers/playerUi/playerUi_Reducer.js
+++ b/packages/client/src/ActionsAndReducers/playerUi/playerUi_Reducer.js
@@ -117,8 +117,6 @@ export const playerUiReducer = (state = initialState, action) => {
     const assetIndex = allForces[forceIndex].assets.findIndex(item => item.name === message.name)
     if (assetIndex === -1) return allForces
     // set the location
-    const { position } = allForces[forceIndex].assets[assetIndex]
-    console.log('asset moved from:' + position + ' to:' + message.position)
     allForces[forceIndex].assets[assetIndex].position = message.position
     return allForces
   }
@@ -378,6 +376,18 @@ export const playerUiReducer = (state = initialState, action) => {
         }
 
         newState.channels = channels
+      })
+
+      // also look for map related messages
+      action.payload.forEach(msg => {
+        // check it's not an infoType
+        if (!msg.infoType) {
+          // do we have forceDelta in the details
+          if (msg.details && msg.details.forceDelta) {
+            // yes, pass it into the force reducer
+            newState.allForces = modifyForcesBasedOnMessage(newState.allForces, { ...msg.message, details: msg.details })
+          }
+        }
       })
 
       break

--- a/packages/client/src/Components/Mapping/helpers/MapPlanningPlayerListener.js
+++ b/packages/client/src/Components/Mapping/helpers/MapPlanningPlayerListener.js
@@ -466,7 +466,9 @@ export default class MapPlanningPlayerListener {
     if (route.length) {
       lastNum = route[route.length - 1].turn
     }
-    const newRoute = { speed: newState.speed, turn: lastNum + 1, state: newState.state }
+    // note: when we send a planned turn, we only need the state name, not the whole
+    // state element
+    const newRoute = { speed: newState.speed, turn: lastNum + 1, state: newState.state.name }
     if (hexList) {
       newRoute.route = hexList
     }

--- a/packages/client/src/Components/Mapping/helpers/MapPlanningUmpireListener.js
+++ b/packages/client/src/Components/Mapping/helpers/MapPlanningUmpireListener.js
@@ -73,7 +73,6 @@ export default class MapPlanningUmpireListener {
       markers.eachLayer(marker => {
         delete marker.context
       })
-
     }
   }
 
@@ -94,9 +93,6 @@ export default class MapPlanningUmpireListener {
     // we need to access this class's data, get
     // it out of the special attribute
     const context = marker.context
-
-    // and delete that context object
-    // delete marker.context
 
     // we have to trick module by pushing capturing marker - so we know
     // who to advance.

--- a/packages/client/src/Components/Mapping/helpers/MapPlanningUmpireListener.js
+++ b/packages/client/src/Components/Mapping/helpers/MapPlanningUmpireListener.js
@@ -53,7 +53,7 @@ export default class MapPlanningUmpireListener {
     this.changesCallback({ payload: visibilityChanges })
   }
 
-  clearListeners () {
+  clearListeners (markers) {
     this.registeredListeners.forEach(pair => {
       pair.marker.off(pair.event)
     })
@@ -67,6 +67,14 @@ export default class MapPlanningUmpireListener {
     this.btnChangeBlueOn.remove()
     this.btnChangeBlueOff.remove()
     this.btnSendChanges.remove()
+
+    // to support the callbacks, we do put this scope context into them. drop it
+    if (markers) {
+      markers.eachLayer(marker => {
+        delete marker.context
+      })
+
+    }
   }
 
   changeVisPopupFor (/* object */asset, /* object */ perceptions) {

--- a/packages/client/src/Components/Mapping/helpers/MapPlanningUmpireListener.js
+++ b/packages/client/src/Components/Mapping/helpers/MapPlanningUmpireListener.js
@@ -88,7 +88,7 @@ export default class MapPlanningUmpireListener {
     const context = marker.context
 
     // and delete that context object
-    delete marker.context
+    // delete marker.context
 
     // we have to trick module by pushing capturing marker - so we know
     // who to advance.

--- a/packages/client/src/Components/Mapping/helpers/createPerceivedStateButtonsFor.js
+++ b/packages/client/src/Components/Mapping/helpers/createPerceivedStateButtonsFor.js
@@ -7,7 +7,7 @@ import { UMPIRE_FORCE } from '../../../consts'
 export default function createPerceivedStateButtonsFor (/* object */asset, /* string */ myForce, /* array strings */ allForces,
   /* array string */ platformTypes, /* object */ context, /* function */ callback, /* array */ existingButtons) {
   if (existingButtons) {
-    existingButtons.forEach(button => button.remove)
+    existingButtons.forEach(button => button.remove())
   }
   const allBtns = [] // maintain full list of buttons, in case UI wants to..
 

--- a/packages/client/src/Components/Mapping/helpers/planningRouteFor.js
+++ b/packages/client/src/Components/Mapping/helpers/planningRouteFor.js
@@ -156,7 +156,7 @@ function markersFor (/* array */ plannedTurns, /* latLng */ start,
   let turnId = 0
   plannedTurns.forEach(turn => {
     const stateSuffix = turn.speed ? ' @ ' + turn.speed + 'kts' : ''
-    const turnName = turnNameFor(turn.turn) + ': ' + turn.state.name + stateSuffix
+    const turnName = turnNameFor(turn.turn) + ': ' + turn.state + stateSuffix
     turnId = turn.turn
 
     // loop through the routes

--- a/packages/client/src/Components/Mapping/index.jsx
+++ b/packages/client/src/Components/Mapping/index.jsx
@@ -217,7 +217,7 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
       // check if clear listeners present
       if (currentPhaseModeRef.current.clearListeners) {
         // detatch the current listener
-        currentPhaseModeRef.current.clearListeners()
+        currentPhaseModeRef.current.clearListeners(platformsLayerRef.current)
       }
 
       // ditch the listener

--- a/packages/client/src/Components/Mapping/index.jsx
+++ b/packages/client/src/Components/Mapping/index.jsx
@@ -308,6 +308,9 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
     const visibleToMe = assetsVisibleToMe(allForces, selectedForce)
     const foundItems = []
     const toDelete = []
+
+    const userIsUmpire = myForceRef.current === 'umpire'
+
     markers.eachLayer(marker => {
       const uniqid = marker.asset.uniqid
       var found = visibleToMe.find(item => item.uniqid === uniqid)
@@ -316,9 +319,11 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
         foundItems.push(uniqid)
 
         const asset = findAsset(allForces, marker.asset.uniqid)
+        if (!asset.force) {
+          asset.force = forceFor(allForces, asset.uniqid)
+        }
 
         // also check it's formatted correctly
-        const userIsUmpire = myForceRef.current === 'umpire'
         const perceptionClassName = findPerceivedAsClasses(perceiveAsForceRef.current, asset.force,
           asset.platformType, asset.perceptions, userIsUmpire)
 
@@ -330,6 +335,7 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
           L.DomUtil.addClass(marker._icon, perceptionClassName)
         }
       } else {
+        // ok, it's no longer visible to me. hide it
         marker.remove()
         toDelete.push(marker)
       }


### PR DESCRIPTION
## 🧰 Ticket
#180 

## 🚀 Overview: 
As the past events load from the database at browser startup, we should be processing map-changing messages.

We should also improve our housekeeping as we move through the phases of the game.

## 🔗 Link to preview

## 🤔 Reason: 
We need the force-changing messages to be re-handled when we reload an existing game

## 🔨Work carried out:

* [x] [fix](https://github.com/serge-web/serge/pull/185/files#diff-7fa0c5bb64e52313fc6720f81a5d4199R381) player reducer 
* [x] [only](https://github.com/serge-web/serge/pull/185/files#diff-ec97d2b163d858b1ba6f0a559a76e693R471) put the state title in for planned turns, not the whole state construct
* [x] [correctly](https://github.com/serge-web/serge/pull/185/files#diff-0a51eb891976f5f833898da19be7d824R10) call the `remove()` method for existing perceived state buttons
* [x] [pass](https://github.com/serge-web/serge/pull/185/files#diff-ccc41ae4337546335419540d2769caefR220) the list of existing markers in the clearListeners method
* [x] [inject](https://github.com/serge-web/serge/pull/185/files#diff-ccc41ae4337546335419540d2769caefR322) the force into an asset if necessary, (for convenience)


- [x] Tests pass

## 🖥️ Screenshot
[If the work is UI related then paste a screenshot of the update here.]

## 📝 Developer Notes:
[Sometimes, extra notes are needed to add clarity to a PR, add them here]