### PR TITLE
Infrastructure Hotfix/try to resolve message passing

### DIFF
--- a/packages/client/src/ActionsAndReducers/playerUi/helpers/handleForceDelta.js
+++ b/packages/client/src/ActionsAndReducers/playerUi/helpers/handleForceDelta.js
@@ -1,0 +1,39 @@
+
+import handleVisibilityChanges from './handleVisibilityChanges'
+import handlePerceptionChange from './handlePerceptionChanges'
+import handleStateOfWorldChanges from './handleStateOfWorldChanges'
+import handleForceLaydownChanges from './handleForceLaydownChanges'
+import handlePlansSubmittedChanges from './handlePlansSubmittedChanges'
+import {
+  FORCE_LAYDOWN,
+  VISIBILIY_CHANGES,
+  PERCEPTION_OF_CONTACT,
+  SUBMIT_PLANS,
+  STATE_OF_WORLD
+} from '../../../consts'
+
+/** create a marker for the supplied set of details */
+export default (/* object */message, /* object */ allForces) => {
+  console.log('message', message)
+  const msgType = message.details.messageType
+  if (!msgType) {
+    console.error('problem - we need message type in ', message)
+  } else {
+    console.log('Player reducer handling forceDelta:', msgType)
+  }
+  switch (msgType) {
+    case FORCE_LAYDOWN:
+      return handleForceLaydownChanges(message, allForces)
+    case VISIBILIY_CHANGES:
+      return handleVisibilityChanges(message, allForces)
+    case PERCEPTION_OF_CONTACT:
+      return handlePerceptionChange(message, allForces)
+    case SUBMIT_PLANS:
+      return handlePlansSubmittedChanges(message, allForces)
+    case STATE_OF_WORLD:
+      return handleStateOfWorldChanges(message, allForces)
+    default:
+      console.error('failed to create player reducer handler for:' + msgType)
+      return allForces
+  }
+}

--- a/packages/client/src/ActionsAndReducers/playerUi/playerUi_Reducer.js
+++ b/packages/client/src/ActionsAndReducers/playerUi/playerUi_Reducer.js
@@ -1,7 +1,6 @@
 import ActionConstant from '../ActionConstants'
 import chat from '../../Schemas/chat.json'
 import copyState from '../../Helpers/copyStateHelper'
-import handleForceDelta from './helpers/handleForceDelta'
 
 import {
   CHAT_CHANNEL_ID,
@@ -95,15 +94,6 @@ export const playerUiReducer = (state = initialState, action) => {
     }
     return { isParticipant, allRolesIncluded, observing, templates }
   }
-
-  const modifyForcesBasedOnMessage = (allForces, message) => {
-    let res = allForces
-    if (message.details && message.details.forceDelta) {
-      res = handleForceDelta(message, allForces)
-    }
-    return res
-  }
-
 
   const reduceTurnMarkers = (message) => {
     if (message.infoType) {
@@ -278,11 +268,6 @@ export const playerUiReducer = (state = initialState, action) => {
         }
       }
 
-      if (action.payload.details && action.payload.details.forceDelta) {
-        // ok, this message relates to the wargame forces data changing. Pass
-        // it to the handler
-        newState.allForces = modifyForcesBasedOnMessage(newState.allForces, { ...action.payload.message, details: action.payload.details })
-      }
       break
 
     case ActionConstant.SET_ALL_MESSAGES:
@@ -339,19 +324,7 @@ export const playerUiReducer = (state = initialState, action) => {
 
         newState.channels = channels
       })
-
-      // also look for map related messages
-      action.payload.forEach(msg => {
-        // check it's not an infoType
-        if (!msg.infoType) {
-          // do we have forceDelta in the details
-          if (msg.details && msg.details.forceDelta) {
-            // yes, pass it into the force reducer
-            newState.allForces = modifyForcesBasedOnMessage(newState.allForces, { ...msg.message, details: msg.details })
-          }
-        }
-      })
-
+    
       break
 
     case ActionConstant.OPEN_MESSAGE:

--- a/packages/client/src/ActionsAndReducers/playerUi/playerUi_Reducer.js
+++ b/packages/client/src/ActionsAndReducers/playerUi/playerUi_Reducer.js
@@ -1,23 +1,15 @@
 import ActionConstant from '../ActionConstants'
 import chat from '../../Schemas/chat.json'
 import copyState from '../../Helpers/copyStateHelper'
-import handleVisibilityChanges from './helpers/handleVisibilityChanges'
-import handlePerceptionChange from './helpers/handlePerceptionChanges'
-import handleStateOfWorldChanges from './helpers/handleStateOfWorldChanges'
-import handleForceLaydownChanges from './helpers/handleForceLaydownChanges'
+import handleForceDelta from './helpers/handleForceDelta'
+
 import {
   CHAT_CHANNEL_ID,
   expiredStorage,
-  LOCAL_STORAGE_TIMEOUT,
-  FORCE_LAYDOWN,
-  VISIBILIY_CHANGES,
-  PERCEPTION_OF_CONTACT,
-  SUBMIT_PLANS,
-  STATE_OF_WORLD
+  LOCAL_STORAGE_TIMEOUT
 } from '../../consts'
 import _ from 'lodash'
 import uniqId from 'uniqid'
-import handlePlansSubmittedChanges from './helpers/handlePlansSubmittedChanges'
 
 export const initialState = {
   selectedForce: '',
@@ -112,29 +104,6 @@ export const playerUiReducer = (state = initialState, action) => {
     return res
   }
 
-  const handleForceDelta = (/* object */message, /* object */ allForces) => {
-    const msgType = message.details.messageType
-    if (!msgType) {
-      console.error('problem - we need message type in ', message)
-    } else {
-      console.log('Player reducer handling forceDelta:', msgType)
-    }
-    switch (msgType) {
-      case FORCE_LAYDOWN:
-        return handleForceLaydownChanges(message, allForces)
-      case VISIBILIY_CHANGES:
-        return handleVisibilityChanges(message, allForces)
-      case PERCEPTION_OF_CONTACT:
-        return handlePerceptionChange(message, allForces)
-      case SUBMIT_PLANS:
-        return handlePlansSubmittedChanges(message, allForces)
-      case STATE_OF_WORLD:
-        return handleStateOfWorldChanges(message, allForces)
-      default:
-        console.error('failed to create player reducer handler for:' + msgType)
-        return allForces
-    }
-  }
 
   const reduceTurnMarkers = (message) => {
     if (message.infoType) {

--- a/packages/client/src/Components/Mapping/helpers/MapAdjudicatingUmpireListener.js
+++ b/packages/client/src/Components/Mapping/helpers/MapAdjudicatingUmpireListener.js
@@ -25,15 +25,18 @@ export default class MapAdjudicatingListener {
     // keep track of who we're listening to
     this.registeredListeners = []
 
-    const context = this
-    this.submitButton = createButton(true, 'Submit 0 of 0 states', () => {
-      context.submitStates()
-    }).addTo(this.map)
-    this.btnListSubmit.push(this.submitButton)
-    this.acceptAllButton = createButton(true, 'Accept remaining 0 states', () => {
-      context.acceptAllStates()
-    }).addTo(this.map)
-    this.btnListSubmit.push(this.acceptAllButton)
+    // don't show the submit buttons if we're on turn zero
+    if (turnNumber > 0) {
+      const context = this
+      this.submitButton = createButton(true, 'Submit 0 of 0 states', () => {
+        context.submitStates()
+      }).addTo(this.map)
+      this.btnListSubmit.push(this.submitButton)
+      this.acceptAllButton = createButton(true, 'Accept remaining 0 states', () => {
+        context.acceptAllStates()
+      }).addTo(this.map)
+      this.btnListSubmit.push(this.acceptAllButton)
+    }
   }
 
   /** accept the planned state for all remaining platforms */
@@ -91,6 +94,7 @@ export default class MapAdjudicatingListener {
 
   clearListeners (markers) {
     this.btnListAccept = clearButtons(this.btnListAccept)
+    this.btnListSubmit = clearButtons(this.btnListSubmit)
   }
 
   showLayer (layer, context) {
@@ -130,10 +134,13 @@ export default class MapAdjudicatingListener {
   }
 
   updateSubmitButtonLabel () {
-    const total = this.allPlatforms.length
-    const count = this.allPlatforms.filter(data => data.newState).length
-    this.submitButton.setText('Submit ' + count + ' of ' + total)
-    this.acceptAllButton.setText('Accept remaining ' + (total - count) + '')
+    // don't have buttons in turn zero
+    if (this.turnNumber > 0) {
+      const total = this.allPlatforms.length
+      const count = this.allPlatforms.filter(data => data.newState).length
+      this.submitButton.setText('Submit ' + count + ' of ' + total)
+      this.acceptAllButton.setText('Accept remaining ' + (total - count) + '')  
+    }
   }
 
   acceptRoute (asset) {

--- a/packages/client/src/api/wargames_api.js
+++ b/packages/client/src/api/wargames_api.js
@@ -813,15 +813,16 @@ export const postNewMessage = (dbName, details, message) => {
 // Copied from postNewMessage cgange and add new logic for Mapping
 // console logs will not works there
 export const postNewMapMessage = (dbName, details, message) => {
-  // const db = wargameDbStore.find((db) => db.name === dbName).db
-  // db.put({
-  //   _id: new Date().toISOString(),
-  //   details,
-  //   message
-  // }).catch((err) => {
-  //   console.log(err)
-  //   return err
-  // })
+  // first, send the message
+  const db = wargameDbStore.find((db) => db.name === dbName).db
+  db.put({
+    _id: new Date().toISOString(),
+    details,
+    message
+  }).catch((err) => {
+    console.log(err)
+    return err
+  })
 
   // also make the modification to the wargame
   return new Promise((resolve, reject) => {
@@ -834,8 +835,6 @@ export const postNewMapMessage = (dbName, details, message) => {
 
         res.data.forces.forces = handleForceDelta(composite, res.data.forces.forces)
 
-        console.log('reduced:', res.data.forces.forces, res)
-        
         return createLatestWargameRevision(dbName, res)
       })
       .then((res) => {
@@ -846,7 +845,6 @@ export const postNewMapMessage = (dbName, details, message) => {
         reject(err)
       })
   })
-
 }
 
 export const getAllMessages = dbName => {

--- a/packages/client/src/api/wargames_api.js
+++ b/packages/client/src/api/wargames_api.js
@@ -15,7 +15,8 @@ import {
   PLANNING_PHASE,
   ADJUDICATION_PHASE,
   MAX_LISTENERS,
-  SERGE_INFO
+  SERGE_INFO,
+  ERROR_THROTTLE
 } from '../consts'
 import {
   setLatestFeedbackMessage,
@@ -43,7 +44,10 @@ const listenNewMessage = ({ db, name, dispatch }) => {
       })()
     })
     .on('error', function (err) {
-      listenNewMessage({ db, name, dispatch, err })
+      // hey, maybe the server is down. introduce a pause
+      setTimeout(e => {
+        listenNewMessage({ db, name, dispatch, err })
+      }, ERROR_THROTTLE)
     })
 }
 

--- a/packages/client/src/consts.js
+++ b/packages/client/src/consts.js
@@ -46,6 +46,12 @@ export const PERCEPTION_OF_CONTACT = 'PerceptionOfContact'
 export const SUBMIT_PLANS = 'SubmitPlans'
 export const STATE_OF_WORLD = 'StateOfWorld'
 
+// time period to wait if server returns an error. One frequent cause of error
+// during development is that the server is stopped.  We're introducing a
+// throttle value to prevent the browser going into a race condition
+// as it sends 1000s of requests to the server
+export const ERROR_THROTTLE = 250
+
 // Nov 2019. Ian modified the server path to use the
 // current URL, so we can use Heroku to provide
 // review instances of the app.  In these


### PR DESCRIPTION
## 🧰 Ticket
Fixes #194 

## 🚀 Overview: 
We _were_ sending messages, then when those messages were received, we applied them to the in-memory wargame.

But, the _other_ way of modifying the wargame (such as in 'next turn') was to pull the most recent copy of the wargame, apply the change, then send the wargame back - which communicates it to everyone.  The down-side of this was that it was overwriting the in-memory copy we were using.

So, now, we send the message, then get an up-to-date wargame, apply the message change, then send the wargame document back out - which gives everyone an up-to-date version.