### PR TITLE
Hotfix - submit routes when current route hasn't been assigned

### DIFF
--- a/packages/client/src/Components/Mapping/helpers/MapAdjudicatingUmpireListener.js
+++ b/packages/client/src/Components/Mapping/helpers/MapAdjudicatingUmpireListener.js
@@ -41,8 +41,6 @@ export default class MapAdjudicatingListener {
 
   /** accept the planned state for all remaining platforms */
   acceptAllStates () {
-    this.acceptAllButton.remove()
-
     // produce the required state
     this.allPlatforms.forEach(data => {
       // has it been accepted yet?
@@ -51,6 +49,7 @@ export default class MapAdjudicatingListener {
         this.acceptRoute(data.asset)
       }
     })
+    this.btnListAccept = clearButtons(this.btnListAccept)
   }
 
   submitStates () {
@@ -90,6 +89,10 @@ export default class MapAdjudicatingListener {
 
     // collate the message
     this.planningFormCallback(message)
+
+    // and drop the submit button
+    this.btnListAccept = clearButtons(this.btnListAccept)
+    this.btnListSubmit = clearButtons(this.btnListSubmit)
   }
 
   clearListeners (markers) {

--- a/packages/client/src/Components/Mapping/helpers/MapPlanningPlayerListener.js
+++ b/packages/client/src/Components/Mapping/helpers/MapPlanningPlayerListener.js
@@ -348,10 +348,12 @@ export default class MapPlanningPlayerListener {
   }
 
   updatePlannedRoute (/* boolean */ detailed) {
-    this.currentRoute.lightRoutes.remove()
-    this.currentRoute.lightRoutes.clearLayers()
-    this.currentRoute.lightRoutes = this.createPlanningRouteFor(this.currentRoute.current, this.currentRoute.marker.asset.history, this.currentRoute.marker.asset, !detailed, detailed)
-    this.storeLayer(this.currentRoute.lightRoutes, this)
+    if (this.currentRoute && this.currentRoute.lightRoutes) {
+      this.currentRoute.lightRoutes.remove()
+      this.currentRoute.lightRoutes.clearLayers()
+      this.currentRoute.lightRoutes = this.createPlanningRouteFor(this.currentRoute.current, this.currentRoute.marker.asset.history, this.currentRoute.marker.asset, !detailed, detailed)
+      this.storeLayer(this.currentRoute.lightRoutes, this)
+    }
   }
 
   /** listen to drag events on the supplied marker */


### PR DESCRIPTION
Clear buttons, and handle issue where UI falls over if a planned route hasn't been selected during a turn

The player UI keeps track of the currently selected track.  It clears this track once the planned routes are submitted. But, we were trying to clear this track when it hadn't been created - throwing an error.