### PR TITLE
[SERGE-170] Attach bypass URL to the role info

### DIFF
--- a/packages/client/src/Views/AdminAndInsightsTabsContainer.jsx
+++ b/packages/client/src/Views/AdminAndInsightsTabsContainer.jsx
@@ -34,11 +34,31 @@ class AdminAndInsightsTabsContainer extends Component {
       insights: 'Insights',
       model: FlexLayout.Model.fromJson(json),
       channelNames: [],
+      byPassUrl: null
     };
+  }
+
+  getByPassUrl() {
+    const [ state ] = this.context
+    const { currentWargame, allForces, selectedForce, selectedRole } = state
+    const currentUrl = new URL(document.location.href)
+    const force = allForces.find(force => force.uniqid === selectedForce)
+    const role = force.roles.find(role => role.name === selectedRole)
+    const byPassParams = {
+      wargame: currentWargame,
+      access: role.password
+    }
+    Object.keys(byPassParams).forEach(key => {
+      currentUrl.searchParams.set(key, byPassParams[key])
+    })
+    this.setState({
+      byPassUrl: currentUrl
+    })
   }
 
   componentDidMount() {
     this.addTabs();
+    this.getByPassUrl();
   }
 
   addTabs() {
@@ -72,6 +92,7 @@ class AdminAndInsightsTabsContainer extends Component {
 
   render() {
     const [ state ] = this.context;
+    const { byPassUrl } = this.state;
     let force = state.allForces.find((force) => force.uniqid === state.selectedForce);
 
     return (
@@ -82,7 +103,11 @@ class AdminAndInsightsTabsContainer extends Component {
           classNameMapper={this.classNameMapper}
         />
         <div className="role-info" style={{ backgroundColor: force.color, }} data-tour="second-step">
-          <span className="role-type">{ state.selectedRole }</span>
+          {
+            byPassUrl ?
+              <a href={byPassUrl} className="role-type">{ state.selectedRole }</a> :
+              <span className="role-type">{ state.selectedRole }</span>
+          }
           <div className="contain-force-skin">
             <div className="force-skin">
               <span className="force-type">{ force.name }</span>

--- a/packages/themes/_playerUi.scss
+++ b/packages/themes/_playerUi.scss
@@ -645,7 +645,6 @@
 .role-info {
   display: block;
   align-items: center;
-  padding: 8px 0 8px 16px;
   position: relative;
   background: $forceDefaultColor;
 
@@ -654,6 +653,13 @@
     font-weight: 600;
     font-style: italic;
     color: $adminColor;
+    display: block;
+    width: 100%;
+    padding: 8px 0 8px 16px;
+
+    &:hover {
+      text-decoration: none;
+    }
   }
 
   .contain-force-skin {
@@ -721,7 +727,7 @@
   border-radius: 4px 0 0 0;
   background: $adminColor;
   overflow: hidden;
-  z-index: 9;
+  z-index: 1000;
 
   .objective-text {
     margin-top: 15px;


### PR DESCRIPTION
## 🧰 Ticket
Closes #170 

## 🚀 Overview: 
Add bypass URL populated from the context state to the role info link

## 🤔 Reason: 
It would be useful to be able to copy this URL from the UI. So, we go through the login process as normal, but once we're in, we can get a copy of the URL params necessary to come back into that role.

## 🔨Work carried out:
- [x] Add bypass URL to role info at `AdminAndInsightsTabsContainer.jsx`
- [x] Update corresponding element's CSS
- [x] Tests pass