### PR TITLE
Bugfix/239 declutter

### DIFF
--- a/packages/client/src/Components/Mapping/helpers/MapPlanningPlayerListener.js
+++ b/packages/client/src/Components/Mapping/helpers/MapPlanningPlayerListener.js
@@ -448,7 +448,7 @@ export default class MapPlanningPlayerListener {
       trimmedRoute = currentRoutes
     }
 
-    return routeLinesFor(trimmedRoute, history, hisLocation, lightweight, this.grid, forceColor, this.waypointCallback, null, highlight, context)
+    return routeLinesFor(trimmedRoute, history, hisLocation, asset.position, lightweight, this.grid, forceColor, this.waypointCallback, null, highlight, context)
   }
 
   /** user has used either the command buttons, or the popup dialog to choose a new platform state */

--- a/packages/client/src/Components/Mapping/helpers/declutterLayer.js
+++ b/packages/client/src/Components/Mapping/helpers/declutterLayer.js
@@ -16,10 +16,12 @@ function descendTree (/* layer */ layer, /* array */ markers) {
   }
 }
 
-function findAllMarkers (/* LayerGroup */ layer) {
+function findAllMarkers (/* LayerGroup */ layers) {
   const markers = []
 
-  descendTree(layer, markers)
+  layers.forEach(layer => {
+    descendTree(layer, markers)
+  })
 
   return markers
 }
@@ -53,9 +55,9 @@ function clusterMarkers (/* array marker */ markers, /* grid */ grid) {
   return res
 }
 
-export default function declutterLayer (/* LayerGroup */ layer, /* object */ grid) {
+export default function declutterLayer (/* array LayerGroup */ layers, /* object */ grid) {
   // get all the markers in the layer(s) first
-  const markers = findAllMarkers(layer)
+  const markers = findAllMarkers(layers)
 
   // now cluster the markers
   const clusters = clusterMarkers(markers, grid)

--- a/packages/client/src/Components/Mapping/helpers/declutterLayer.js
+++ b/packages/client/src/Components/Mapping/helpers/declutterLayer.js
@@ -27,36 +27,25 @@ function findAllMarkers (/* LayerGroup */ layer) {
 function clusterMarkers (/* array marker */ markers, /* grid */ grid) {
   const res = []
   markers.forEach(marker => {
-    let pos
+    let hex
     if (marker.do_not_declutter) {
       // ok, special handling, we have an item that doesn't want to be decluttered
       if (marker.getLayers) {
         // ok, it's several items that shouldn't be separated, but clustered as one
         const firstChild = marker.getLayers()[0]
-        pos = firstChild.getLatLng()
+        hex = firstChild.hex
       } else {
         // single item that doesn't want to be decluttered, ignore it
-        pos = null
+        hex = null
       }
     } else {
-      pos = marker.getLatLng()
+      hex = marker.hex
     }
-    if (pos) {
-      let index
-      // NOTE: 1. We may not have the grid, if it's a unit test
-      // NOTE: 2. Also, on occasion, the decluttering may push
-      // an item beyond the edge of the map, in which case
-      // cellFor will return null
-      if (grid.cellFor && grid.cellFor(pos)) {
-        const thisCell = grid.cellFor(pos)
-        index = thisCell.name
-      } else {
-        index = pos.lat + ',' + pos.lng
-      }
-      let list = res[index]
+    if (hex) {
+      let list = res[hex]
       if (!list) {
         list = []
-        res[index] = list
+        res[hex] = list
       }
       list.push(marker)
     }
@@ -72,5 +61,5 @@ export default function declutterLayer (/* LayerGroup */ layer, /* object */ gri
   const clusters = clusterMarkers(markers, grid)
 
   // sort markers out into clusters
-  declutterMarkers(clusters, grid.delta / 3)
+  declutterMarkers(clusters, grid.delta / 3, grid)
 }

--- a/packages/client/src/Components/Mapping/helpers/declutterMarkers.js
+++ b/packages/client/src/Components/Mapping/helpers/declutterMarkers.js
@@ -2,11 +2,15 @@ import L from 'leaflet'
 /** some cells may contain multiple markers. if that's the case, spread them out around the cell.
    * The clusters object should contain a list of arrays of markers
    */
-export default function declutter (/* collection */ clusters, /* degrees */ gridDelta) {
+export default function declutter (/* collection */ clusters, /* degrees */ gridDelta, /* object */ grid) {
   // note: we need to have the 'locIgnored' parameter in the next line, but it remains unsed
   // This next line tells esLint not worry about it
   /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "Ignored" }] */
-  for (const [locIgnored, list] of Object.entries(clusters)) {
+  // const keys = Object.keys(clusters)
+  // console.log('keys:', keys)
+  for (const key in clusters) {
+    const list = clusters[key]
+    const centre = grid.hexNamed(key).centrePos
     const len = list.length
     if (len > 1) {
       // note: we start at 1, since we let the first one stay in the middle
@@ -16,15 +20,16 @@ export default function declutter (/* collection */ clusters, /* degrees */ grid
         const thisAngleRads = (90 + thisAngleDegs) / 180 * Math.PI
 
         const updatePos = (marker) => {
-          const thisPos = marker.getLatLng()
-          const newLat = thisPos.lat + gridDelta * Math.sin(thisAngleRads)
-          const newLng = thisPos.lng + gridDelta * Math.cos(thisAngleRads)
+          const newLat = centre.lat + gridDelta * Math.sin(thisAngleRads)
+          const newLng = centre.lng + gridDelta * Math.cos(thisAngleRads)
           marker.setLatLng(L.latLng(newLat, newLng))
         }
 
         if (marker.do_not_declutter) {
           if (marker.eachLayer) {
-            marker.eachLayer(marker => updatePos(marker))
+            marker.eachLayer(marker => {
+              updatePos(marker)
+            })
           } else {
             // note: we mark the planningMarker with do not declutter, since we
             // want it to stay in the centre of a cell

--- a/packages/client/src/Components/Mapping/helpers/markerFor.js
+++ b/packages/client/src/Components/Mapping/helpers/markerFor.js
@@ -24,6 +24,7 @@ export default (asset, grid, force, myForce, platformTypes, userIsUmpire, /* str
     res.bindTooltip(asset.name)
     res.name = asset.name
     res.force = asset.force
+    res.hex = asset.position // store the hex coords for use in de-cluttering
 
     // sort out the travel mode for this platform type
     const pType = findPlatformTypeFor(platformTypes, asset.platformType)

--- a/packages/client/src/Components/Mapping/index.jsx
+++ b/packages/client/src/Components/Mapping/index.jsx
@@ -27,9 +27,7 @@ import './styles.scss'
 // TODO: Refactor. We should convert the next file into a module
 import './leaflet.zoomhome.js'
 
-import handlePerceptionChanges from '../../ActionsAndReducers/playerUi/helpers/handlePerceptionChanges'
 import MappingForm from './components/FormContainer'
-import handleStateOfWorldChanges from '../../ActionsAndReducers/playerUi/helpers/handleStateOfWorldChanges'
 
 const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, allPlatforms, phase, channelID, imageTop, imageLeft, imageBottom, imageRight }) => {
   const mapRef = useRef(null) // the leaflet map
@@ -149,13 +147,10 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
   const perceivedStateCallback = (/* string */ assetid, /* string */ perceivedBy, /* object */ perception) => {
     const perceivedType = { asset: assetid, force: perceivedBy, perception: perception }
     sendMessage(PERCEPTION_OF_CONTACT, perceivedType)
-    handlePerceptionChanges(perceivedType, allForces)
   }
 
   const routeCompleteCallback = (/* object */payload) => {
     sendMessage(SUBMIT_PLANS, payload)
-    // also call the reducer ourselves
-  //  handlePlansSubmittedChanges(payload, allForces)
   }
 
   const clearControlledAssets = () => {
@@ -163,8 +158,6 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
 
   const newStateOfWorldCallback = (payload) => {
     sendMessage(STATE_OF_WORLD, payload)
-    // also call the reducer ourselves
-    handleStateOfWorldChanges(payload, allForces)
   }
 
   // run the declutter algorithm, to distribute markers around a cell if necessary

--- a/packages/client/src/Components/Mapping/index.jsx
+++ b/packages/client/src/Components/Mapping/index.jsx
@@ -169,7 +169,8 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
 
   // run the declutter algorithm, to distribute markers around a cell if necessary
   const declutterCallback = () => {
-    declutterLayer(currentPhaseMapRef.current, gridImplRef.current)
+    const allLayers = [currentPhaseMapRef.current, platformsLayerRef.current]
+    declutterLayer(allLayers, gridImplRef.current)
   }
 
   const createThisMarker = (asset, grid, force) => {

--- a/packages/client/src/Tests/mappingHelpers/declutterLayer.test.js
+++ b/packages/client/src/Tests/mappingHelpers/declutterLayer.test.js
@@ -9,25 +9,34 @@ function addMarker (/* number */ lat, /* number */ lng, /* string */ hex) {
 }
 
 it('Declutters markers in Leaflet layer tree', () => {
-  const top = L.layerGroup()
-  const oneA = L.layerGroup().addTo(top)
-  const oneB = L.layerGroup().addTo(top)
+  const topA = L.layerGroup()
+  const topB = L.layerGroup()
+  const oneA = L.layerGroup().addTo(topA)
+  const oneB = L.layerGroup().addTo(topA)
   const twoA = L.layerGroup().addTo(oneA)
   // expect(forceFor(allForces, 'echo')).toEqual('Green')
   const m1 = addMarker(12, 13, 'aa')
   const m2 = addMarker(13, 14, 'bb')
   const m3 = addMarker(14, 15, 'cc')
   const m4 = addMarker(12, 13, 'aa')
-  top.addLayer(m1)
+  const m5 = addMarker(14, 15, 'cc')
+  const m6 = addMarker(12, 13, 'aa')
+  topA.addLayer(m1)
   oneA.addLayer(m2)
   oneB.addLayer(m3)
   twoA.addLayer(m4)
+  topB.addLayer(m5)
+  topB.addLayer(m6)
 
   // check the "before"
   expect(m4.getLatLng().lat).toBeCloseTo(12)
   expect(m4.getLatLng().lng).toBeCloseTo(13)
+
   expect(m1.getLatLng().lat).toBeCloseTo(12)
   expect(m1.getLatLng().lng).toBeCloseTo(13)
+
+  expect(m2.getLatLng().lat).toBeCloseTo(13)
+  expect(m2.getLatLng().lng).toBeCloseTo(14)
 
   const dict = {
     aa: { lat: 12, lng: 13 },
@@ -40,12 +49,14 @@ it('Declutters markers in Leaflet layer tree', () => {
       return { centrePos: dict[name] }
     }
   }
-  declutterLayer(top, grid)
+  declutterLayer([topA, topB], grid)
 
   // note: the essential part of the following tests is that
   // two of the cells have been re-arranged
   expect(m4.getLatLng().lat).toBeCloseTo(12.0833333)
   expect(m4.getLatLng().lng).toBeCloseTo(13)
-  expect(m1.getLatLng().lat).toBeCloseTo(11.9166667)
-  expect(m1.getLatLng().lng).toBeCloseTo(13)
+  expect(m1.getLatLng().lat).toBeCloseTo(11.958)
+  expect(m1.getLatLng().lng).toBeCloseTo(12.927)
+  expect(m2.getLatLng().lat).toBeCloseTo(13)
+  expect(m2.getLatLng().lng).toBeCloseTo(14)
 })

--- a/packages/client/src/Tests/mappingHelpers/declutterLayer.test.js
+++ b/packages/client/src/Tests/mappingHelpers/declutterLayer.test.js
@@ -2,8 +2,10 @@
 import L from 'leaflet'
 import declutterLayer from '../../Components/Mapping/helpers/declutterLayer'
 
-function addMarker (/* number */ lat, /* number */ lng) {
-  return L.marker([lat, lng], { icon: 'icon-name' })
+function addMarker (/* number */ lat, /* number */ lng, /* string */ hex) {
+  const marker = L.marker([lat, lng], { icon: 'icon-name' })
+  marker.hex = hex
+  return marker
 }
 
 it('Declutters markers in Leaflet layer tree', () => {
@@ -12,10 +14,10 @@ it('Declutters markers in Leaflet layer tree', () => {
   const oneB = L.layerGroup().addTo(top)
   const twoA = L.layerGroup().addTo(oneA)
   // expect(forceFor(allForces, 'echo')).toEqual('Green')
-  const m1 = addMarker(12, 13)
-  const m2 = addMarker(13, 14)
-  const m3 = addMarker(14, 15)
-  const m4 = addMarker(12, 13)
+  const m1 = addMarker(12, 13, 'aa')
+  const m2 = addMarker(13, 14, 'bb')
+  const m3 = addMarker(14, 15, 'cc')
+  const m4 = addMarker(12, 13, 'aa')
   top.addLayer(m1)
   oneA.addLayer(m2)
   oneB.addLayer(m3)
@@ -27,7 +29,17 @@ it('Declutters markers in Leaflet layer tree', () => {
   expect(m1.getLatLng().lat).toBeCloseTo(12)
   expect(m1.getLatLng().lng).toBeCloseTo(13)
 
-  const grid = { delta: 0.08333 * 3}
+  const dict = {
+    aa: { lat: 12, lng: 13 },
+    bb: { lat: 13, lng: 14 },
+    cc: { lat: 14, lng: 15 }
+  }
+  const grid = {
+    delta: 0.08333 * 3,
+    hexNamed: (name) => {
+      return { centrePos: dict[name] }
+    }
+  }
   declutterLayer(top, grid)
 
   // note: the essential part of the following tests is that


### PR DESCRIPTION
## 🧰 Ticket
Fixes #239 

Before:
![image](https://user-images.githubusercontent.com/1108513/73137504-a8191980-4050-11ea-9315-c277de6e3849.png)


After:
![image](https://user-images.githubusercontent.com/1108513/73137498-959ee000-4050-11ea-8f40-0779829258a1.png)


## 🚀 Overview: 
We were using the locations of the markers as indices for the clustering.  But, this meant they were slowly being pushed further out as they tried to decluster fake clusters.  Instead, we store the hex cell id in the marker, and use these as indices.