### PR TITLE
Fix/229 box shadow

### DIFF
--- a/packages/client/src/Components/Mapping/styles.scss
+++ b/packages/client/src/Components/Mapping/styles.scss
@@ -28,6 +28,7 @@
   background-repeat: no-repeat;
   background-position: center;
   background-size: 80%;
+  box-shadow: 4px 4px 3px rgba(0, 0, 0, 0.45);
 }
 
 .platform-force {

--- a/packages/client/src/Components/Mapping/styles.scss
+++ b/packages/client/src/Components/Mapping/styles.scss
@@ -75,7 +75,6 @@ div.map-turn-marker {
 
 .leaflet-marker-icon {
   border: 1px solid rgba(255, 255, 255, 0.6);
-  box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25);
   &.selected {
     border: 4px solid rgba(255, 255, 255, .5);
   }


### PR DESCRIPTION
## 🧰 Ticket
Fixes #229 

Before:
![image](https://user-images.githubusercontent.com/1108513/73137666-90db2b80-4052-11ea-96e2-eeaee017a466.png)


After:
![image](https://user-images.githubusercontent.com/1108513/73137664-84ef6980-4052-11ea-9f75-3ca82637ad0f.png)


## 🚀 Overview: 
Remove box shadow from all leaflet markers, just apply it to counters.

increase depth of shadow on counters