### PR TITLE
introduce arrow head for end of planned route

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -23,6 +23,7 @@
     "json-metaschema": "^1.2.0",
     "leaflet": "^1.6.0",
     "leaflet-easybutton": "^2.4.0",
+    "leaflet-polylinedecorator": "^1.6.0",
     "leaflet.icon.glyph": "^0.2.1",
     "lodash": "^4.17.15",
     "lorem-ipsum": "^2.0.3",

--- a/packages/client/src/Components/Mapping/helpers/routeLinesFor.js
+++ b/packages/client/src/Components/Mapping/helpers/routeLinesFor.js
@@ -1,4 +1,5 @@
 import L from 'leaflet'
+import 'leaflet-polylinedecorator'
 
 // the images we use to annotate planning legs
 import turnLeft from '../images/turn-left.png'
@@ -79,6 +80,22 @@ function lineFor (/* array */ turns, /* latLng */ start,
         boldLatLongs.push(start)
       }
       boldLine.setLatLngs(boldLatLongs)
+      const arrowSize = lightweight ? 8 : 15
+      var arrowHead = L.polylineDecorator(boldLine, {
+        patterns: [{
+          offset: '100%',
+          repeat: 0,
+          symbol: L.Symbol.arrowHead({
+            pixelSize: arrowSize,
+            polygon: true,
+            pathOptions: {
+              color: color,
+              stroke: true
+            }
+          })
+        }]
+      })
+      res.addLayer(arrowHead)
       res.addLayer(boldLine)
     }
     boldLine.setLatLngs(boldLatLongs)

--- a/packages/client/src/Components/Mapping/helpers/routeLinesFor.js
+++ b/packages/client/src/Components/Mapping/helpers/routeLinesFor.js
@@ -80,11 +80,10 @@ function lineFor (/* array */ turns, /* latLng */ start,
         boldLatLongs.push(start)
       }
       boldLine.setLatLngs(boldLatLongs)
-      const arrowSize = lightweight ? 8 : 15
+      const arrowSize = lightweight ? 8 : 12
       var arrowHead = L.polylineDecorator(boldLine, {
         patterns: [{
           offset: '100%',
-          repeat: 0,
           symbol: L.Symbol.arrowHead({
             pixelSize: arrowSize,
             polygon: true,


### PR DESCRIPTION
## 🧰 Ticket
Fixes #214 

Before:
![image](https://user-images.githubusercontent.com/1108513/73138057-64c1a980-4056-11ea-815c-253609c81b34.png)


After:
![image](https://user-images.githubusercontent.com/1108513/73138049-52e00680-4056-11ea-9684-4d90698c8427.png)


## 🚀 Overview: 
We're using the `Leaflet.PolylineDecorator` utility to draw an arrow at the end of the planned route - as a reminder of the direction of travel. 

See UX for these arrows here:
![image](https://user-images.githubusercontent.com/1108513/73138081-9b97bf80-4056-11ea-96da-7722347652c0.png)
 
