### PR TITLE
Introduce button to allow player to clear all planned turns

### DIFF
--- a/packages/client/src/Components/Mapping/helpers/MapPlanningPlayerListener.js
+++ b/packages/client/src/Components/Mapping/helpers/MapPlanningPlayerListener.js
@@ -225,6 +225,20 @@ export default class MapPlanningPlayerListener {
         this.btnListStates = createStateButtonsFor(pType, marker.asset.name, this, this.stateSelectedCallback, this.btnListStates)
       }
 
+      // if there are any planned route turns, invite to clear them
+      if (this.currentRoute.current && this.currentRoute.current.length) {
+        const clearTurns = createButton(true, 'Clear planned turns', () => {
+          this.currentRoute.current = []
+          if(this.planningMarker) {
+            this.planningMarker.remove()
+          }
+          this.clearAchievableCells()
+          this.updatePlannedRoute(false)
+          clearTurns.remove()
+        }).addTo(this.map)
+        this.btnListStates.push(clearTurns)
+      }
+
       // ok, the popup will eventually manage state
       marker.options.draggable = false
     }


### PR DESCRIPTION
## 🧰 Ticket
Fixes #228 

## 🚀 Overview: 
Introduce UI button to allow a player to clear all planned turns. We were formerly only able to click on a future planned turn and remove all legs from there on. Now we can do it from the start.