### PR TITLE
Hotfix - formatting on leaflet marker pins

### DIFF
--- a/packages/client/src/Components/Mapping/styles.scss
+++ b/packages/client/src/Components/Mapping/styles.scss
@@ -29,6 +29,10 @@
   background-position: center;
   background-size: 80%;
   box-shadow: 4px 4px 3px rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  &.selected {
+    border: 4px solid rgba(255, 255, 255, .5);
+  }
 }
 
 .platform-force {
@@ -72,11 +76,4 @@ div.map-turn-marker {
   width: 200px;
   padding-left: 15px;
   color: #000;
-}
-
-.leaflet-marker-icon {
-  border: 1px solid rgba(255, 255, 255, 0.6);
-  &.selected {
-    border: 4px solid rgba(255, 255, 255, .5);
-  }
 }


### PR DESCRIPTION
We have styling for counters, but it was mistakenly being applied to all leaflet icons.

We 'caught' the shadow/border formatting, but not the 1px standard border.

So, put the formatting on the planning marker, not all leaflet icons.

Before:
![image](https://user-images.githubusercontent.com/1108513/73176111-8e84da00-4103-11ea-97af-08e32cff23bc.png)


After:
![image](https://user-images.githubusercontent.com/1108513/73175976-4d8cc580-4103-11ea-9a1c-310ab3b6ee40.png)

