### PR TITLE
Cosmetically indicate if platform in non-standard condition

### DIFF
--- a/packages/client/src/Components/Mapping/helpers/markerFor.js
+++ b/packages/client/src/Components/Mapping/helpers/markerFor.js
@@ -21,14 +21,24 @@ export default (asset, grid, force, myForce, platformTypes, userIsUmpire, /* str
         icon: divIcon
       }
     )
-    res.bindTooltip(asset.name)
-    res.name = asset.name
-    res.force = asset.force
-    res.hex = asset.position // store the hex coords for use in de-cluttering
 
     // sort out the travel mode for this platform type
     const pType = findPlatformTypeFor(platformTypes, asset.platformType)
     res.travelMode = pType.travelMode
+
+    // for a non-standard condition, we display a longer title
+    if (pType.conditions && pType.conditions.length > 0) {
+      if (pType.conditions[0] !== asset.condition) {
+        asset.nonStandardCondition = true
+      }
+    }
+    
+    const hoverTxt = asset.nonStandardCondition ? asset.name + ' - ' + asset.condition : asset.condition   
+
+    res.bindTooltip(hoverTxt)
+    res.name = asset.name
+    res.force = asset.force
+    res.hex = asset.position // store the hex coords for use in de-cluttering
 
     // oh, come on - just take a copy of everything
     res.asset = asset

--- a/packages/client/src/Components/Mapping/index.jsx
+++ b/packages/client/src/Components/Mapping/index.jsx
@@ -189,6 +189,17 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
       if (marker != null) {
         currentPhaseModeRef.current.listenTo(marker, currentTurn)
         platformsLayerRef.current.addLayer(marker)
+
+        // Note: we may wish to add a CSS class to the counter. But, we can only do this if
+        // it has already been added to the map. Perform last bit of `markerFor` processing here:
+        // is the condition different to the first one listed
+        const pType = asset.platformTypeDetail
+        if (pType.conditions && pType.conditions.length > 0) {
+          if (pType.conditions[0] !== asset.condition) {
+            // apply styling
+            L.DomUtil.addClass(marker._icon, 'platform-abnormal-condition')
+          }
+        }
       }
     }
   }

--- a/packages/client/src/Components/Mapping/index.jsx
+++ b/packages/client/src/Components/Mapping/index.jsx
@@ -193,12 +193,10 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
         // Note: we may wish to add a CSS class to the counter. But, we can only do this if
         // it has already been added to the map. Perform last bit of `markerFor` processing here:
         // is the condition different to the first one listed
-        const pType = asset.platformTypeDetail
-        if (pType.conditions && pType.conditions.length > 0) {
-          if (pType.conditions[0] !== asset.condition) {
-            // apply styling
-            L.DomUtil.addClass(marker._icon, 'platform-abnormal-condition')
-          }
+        if (asset.nonStandardCondition) {
+          // apply styling
+          L.DomUtil.addClass(marker._icon, 'platform-abnormal-condition')
+          L.DomUtil.addClass(marker._icon, 'platform-abnormal-' + asset.condition)
         }
       }
     }

--- a/packages/client/src/Components/Mapping/styles.scss
+++ b/packages/client/src/Components/Mapping/styles.scss
@@ -42,26 +42,26 @@
   &-blue {
    background-color: #000fff;   
    &.platform-abnormal-condition {
-    background-color: #000a91;
+    background-color: #d4d7fc;
   }
 }
   &-red {
     background-color: #ff0000;
     &.platform-abnormal-condition {
-      background-color: #8f0303;
+      background-color: #ffcece;
     }
   }
   &-green {
     background-color: #19bd37;
     &.platform-abnormal-condition {
-      background-color: #0e6a1f;
+      background-color: #ADC3AC;
     }
     }
   &-unknown {
     background-color: #999; 
    }
    &.platform-abnormal-condition {
-    background-color: rgb(82, 82, 82);
+    background-color: rgb(222, 222, 222);
   }
 }
 

--- a/packages/client/src/Components/Mapping/styles.scss
+++ b/packages/client/src/Components/Mapping/styles.scss
@@ -28,7 +28,7 @@
   background-repeat: no-repeat;
   background-position: center;
   background-size: 80%;
-  box-shadow: 4px 4px 3px rgba(0, 0, 0, 0.45);
+  box-shadow: 3px 3px 2px rgba(0, 0, 0, 0.25);
   border: 1px solid rgba(255, 255, 255, 0.6);
   &.selected {
     border: 4px solid rgba(255, 255, 255, .7);

--- a/packages/client/src/Components/Mapping/styles.scss
+++ b/packages/client/src/Components/Mapping/styles.scss
@@ -30,9 +30,6 @@
   background-size: 80%;
   box-shadow: 4px 4px 3px rgba(0, 0, 0, 0.45);
   border: 1px solid rgba(255, 255, 255, 0.6);
-  &.platform-abnormal-condition {
-    border: 4px solid rgba(130, 130, 130, .85);
-  }
   &.selected {
     border: 4px solid rgba(255, 255, 255, .7);
   }
@@ -41,17 +38,29 @@
 .platform-force {
   &-blue {
    background-color: #000fff; 
+   &.platform-abnormal-condition {
+    background-color: #000a91;
   }
+}
   &-red {
     background-color: #ff0000;
+    &.platform-abnormal-condition {
+      background-color: #8f0303;
+    }
   }
   &-green {
     background-color: #19bd37;
-  }
+    &.platform-abnormal-condition {
+      background-color: #0e6a1f;
+    }
+    }
   &-unknown {
     background-color: #999; 
    }
- }
+   &.platform-abnormal-condition {
+    background-color: rgb(82, 82, 82);
+  }
+}
 
  .leaflet-popup-content-wrapper {
    background-color: rgba(#fff, .8);

--- a/packages/client/src/Components/Mapping/styles.scss
+++ b/packages/client/src/Components/Mapping/styles.scss
@@ -36,8 +36,11 @@
 }
 
 .platform-force {
+  // Note: in the longer term these shades should come form the force element
+  // of the wargame definition. When that happens we will probably need to use
+  // HSL conversions to make the abnormal condition shades darker.
   &-blue {
-   background-color: #000fff; 
+   background-color: #000fff;   
    &.platform-abnormal-condition {
     background-color: #000a91;
   }

--- a/packages/client/src/Components/Mapping/styles.scss
+++ b/packages/client/src/Components/Mapping/styles.scss
@@ -30,8 +30,11 @@
   background-size: 80%;
   box-shadow: 4px 4px 3px rgba(0, 0, 0, 0.45);
   border: 1px solid rgba(255, 255, 255, 0.6);
+  &.platform-abnormal-condition {
+    border: 4px solid rgba(130, 130, 130, .85);
+  }
   &.selected {
-    border: 4px solid rgba(255, 255, 255, .5);
+    border: 4px solid rgba(255, 255, 255, .7);
   }
 }
 


### PR DESCRIPTION
## 🧰 Ticket
Supports #240 

## 🚀 Overview: 
We're saying an asset is in a non-standard condition if its condition is something other than the first one listed.
When this applies, we'll cosmetically modify the marker - to encourage the user to hover over it.

This is currently done by applying a grey border to the marker. But, this border is lost when the marker switches to its 'selected' light-grey border.

## 🖥️ Screenshot
![image](https://user-images.githubusercontent.com/1108513/73181432-191f0680-410f-11ea-93f0-f4902f2edc69.png)

But, really @clenoble  would like the counter to take a grey shade all over:
![image](https://user-images.githubusercontent.com/1108513/73182621-48cf0e00-4111-11ea-807d-1a94cb35d4ce.png)

@foxleigh81 - do you have any CSS tricks that will give the grey "wash" over the image?

(I'm reluctant to create another image _over_ this one, since we'll be introducing more entities on the map, and it may introduce click-handler troubles.

## Preview

