### PR TITLE
the check to display speed (kts) or 'for x turns' is now controlled b…

### DIFF
--- a/packages/client/src/Components/Mapping/components/FormChildPlannedStatus/index.jsx
+++ b/packages/client/src/Components/Mapping/components/FormChildPlannedStatus/index.jsx
@@ -5,6 +5,7 @@ const PlannedStatus = ({ store, onStoreUpdate, callbackFunction }) => {
   const [markerStatus, setMarkerStatus] = useState(store.currentMarkerStatus)
   const [markerSpeed, setMarkerSpeed] = useState(store.currentMarkerSpeed)
   const [turnsInThisState, setTurnsInThisState] = useState(store.turnsInThisState)
+  const [isMobile, setIsMobile] = useState(store.currentMarkerIsMobile)
 
   // Get all of the possible states and speeds
   const { states, speedKts } = currentMarker.platformTypeDetail
@@ -20,8 +21,11 @@ const PlannedStatus = ({ store, onStoreUpdate, callbackFunction }) => {
   }
 
   const handleStatusChange = ({ target }) => {
+    const isMobileCheck = states.find(state => state.name === target.value).mobile
     setMarkerStatus(target.value)
+    setIsMobile(isMobileCheck)
     newStore.currentMarkerStatus = target.value
+    newStore.currentMarkerIsMobile = isMobileCheck
     // save data in helper class to not lose it after popup recreate
     onStoreUpdate(newStore)
   }
@@ -34,7 +38,7 @@ const PlannedStatus = ({ store, onStoreUpdate, callbackFunction }) => {
     onStoreUpdate(newStore)
   }
 
-  const handleMooredChange = ({ target }) => {
+  const handleMobileChange = ({ target }) => {
     const val = parseInt(target.value)
     setTurnsInThisState(val)
     newStore.turnsInThisState = val
@@ -60,7 +64,7 @@ const PlannedStatus = ({ store, onStoreUpdate, callbackFunction }) => {
           }
         </ul>
       </div>
-      { (speedKts.length && markerStatus !== 'Moored') &&
+      { (speedKts.length && isMobile) &&
         <div className="input-container radio">
           <label htmlFor="speed">Speed (kts)</label>
           <ul>
@@ -78,11 +82,11 @@ const PlannedStatus = ({ store, onStoreUpdate, callbackFunction }) => {
         </div>
       }
       {
-        markerStatus === 'Moored' &&
+        !isMobile &&
         <div className="input-container short-number">
           <label>
             For
-            <input onChange={handleMooredChange} type="number" value={turnsInThisState} />
+            <input onChange={handleMobileChange} type="number" value={turnsInThisState} />
             turns
           </label>
         </div>

--- a/packages/client/src/Components/Mapping/components/FormChildPlannedStatus/index.jsx
+++ b/packages/client/src/Components/Mapping/components/FormChildPlannedStatus/index.jsx
@@ -24,8 +24,13 @@ const PlannedStatus = ({ store, onStoreUpdate, callbackFunction }) => {
     const isMobileCheck = states.find(state => state.name === target.value).mobile
     setMarkerStatus(target.value)
     setIsMobile(isMobileCheck)
+
     newStore.currentMarkerStatus = target.value
     newStore.currentMarkerIsMobile = isMobileCheck
+    if (!isMobileCheck) {
+      setMarkerSpeed(null)
+      newStore.currentMarkerSpeed = null
+    }
     // save data in helper class to not lose it after popup recreate
     onStoreUpdate(newStore)
   }

--- a/packages/client/src/Components/Mapping/index.jsx
+++ b/packages/client/src/Components/Mapping/index.jsx
@@ -233,7 +233,7 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
     } else {
       currentPhaseModeRef.current = new MapPlanningPlayerListener(currentPhaseMapRef.current, mapRef.current, gridImplRef.current,
         myForceRef.current, currentTurn, routeCompleteCallback,
-        platformTypesRef.current, allForces, declutterCallback, perceivedStateCallback, forceNames, phase, 
+        platformTypesRef.current, allForces, declutterCallback, perceivedStateCallback, forceNames, phase,
         newStateOfWorldCallback, visChangesFunc, allRoutes)
     }
 
@@ -315,6 +315,10 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
         marker.remove()
         toDelete.push(marker)
       }
+
+      // work out if the current state is mobile or not
+      const markerState = marker.asset.platformTypeDetail.states.find(state => state.name === marker.asset.status.state)
+
       // Show a form on popup
       const popup = new MapPopupHelper(mapRef.current, marker)
       popup.setStore({
@@ -323,7 +327,8 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
         currentMarker: marker.asset,
         currentMarkerName: marker.asset.name,
         currentMarkerForce: marker.asset.force,
-        currentMarkerStatus: marker.asset.status.state,
+        currentMarkerStatus: markerState.name,
+        currentMarkerIsMobile: markerState.mobile,
         currentMarkerSpeed: marker.asset.status.speedKts,
         turnsInThisState: 0,
         perception: marker.asset.perceptions[myForceRef.current] || null,

--- a/packages/client/src/Components/Mapping/index.jsx
+++ b/packages/client/src/Components/Mapping/index.jsx
@@ -330,7 +330,7 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
         currentMarkerStatus: markerState.name,
         currentMarkerIsMobile: markerState.mobile,
         currentMarkerSpeed: marker.asset.status.speedKts,
-        turnsInThisState: 0,
+        turnsInThisState: 1,
         perception: marker.asset.perceptions[myForceRef.current] || null,
         allForces,
         allPlatforms


### PR DESCRIPTION
## 🧰 Ticket
Fixes issue raised in #165 

## 🚀 Overview: 
The determining factor for showing or hiding the speed(kts)/for x turns elements was set to use the `mooring` state, this was incorrect and has now been changed to use the `mobile` state.
