### PR TITLE
Feature/interpret map as other force

### DIFF
--- a/packages/client/src/Components/Mapping/helpers/MapPlanningPlayerListener.js
+++ b/packages/client/src/Components/Mapping/helpers/MapPlanningPlayerListener.js
@@ -106,7 +106,8 @@ export default class MapPlanningPlayerListener {
       const btns = []
       forceNames.forEach(name => {
         const color = colorFor(name)
-        const button = L.easyButton('<span style="font-size:14px;color:' + color + ';" class="fa fa-eye"/>', () => {
+        const title = 'View as ' + name
+        const button = L.easyButton('<span title="' + title + '" style="font-size:16px;color:' + color + ';" class="fa fa-eye"/>', () => {
           context.viewAs(name, allMarkers)
         })
         btns.push(button)

--- a/packages/client/src/Components/Mapping/helpers/MapPlanningPlayerListener.js
+++ b/packages/client/src/Components/Mapping/helpers/MapPlanningPlayerListener.js
@@ -108,8 +108,18 @@ export default class MapPlanningPlayerListener {
         const color = colorFor(name)
         const title = 'View as ' + name
         const button = L.easyButton('<span title="' + title + '" style="font-size:16px;color:' + color + ';" class="fa fa-eye"/>', () => {
+          // update the UI
           context.viewAs(name, allMarkers)
+          // clear any other selected states
+          btns.forEach(btn => {
+            btn.enable()
+          })
+          button.disable()
         })
+        // if this is the first one, mark it as selected
+        if (!btns.length) {
+          button.disable()
+        }
         btns.push(button)
       })
       this.viewAsBar = L.easyBar(btns).addTo(this.map)

--- a/packages/client/src/Components/Mapping/index.jsx
+++ b/packages/client/src/Components/Mapping/index.jsx
@@ -251,7 +251,7 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
       currentPhaseModeRef.current = new MapPlanningPlayerListener(currentPhaseMapRef.current, mapRef.current, gridImplRef.current,
         myForceRef.current, currentTurn, routeCompleteCallback,
         platformTypesRef.current, allForces, declutterCallback, perceivedStateCallback, forceNames, phase,
-        newStateOfWorldCallback, visChangesFunc, allRoutes, reactForms)
+        newStateOfWorldCallback, visChangesFunc, allRoutes, reactForms, platformsLayerRef.current)
     }
 
     // create markers, and listen to them

--- a/packages/client/src/Components/Mapping/styles.scss
+++ b/packages/client/src/Components/Mapping/styles.scss
@@ -111,3 +111,7 @@ div.map-turn-marker {
   padding-left: 15px;
   color: #000;
 }
+
+.marker-hidden {
+  visibility: hidden;
+}

--- a/packages/client/src/Components/Mapping/styles.scss
+++ b/packages/client/src/Components/Mapping/styles.scss
@@ -116,8 +116,14 @@ div.map-turn-marker {
   visibility: hidden;
 }
 
+/** this is the easyBar component, that contains a collection of buttons */
 .easy-button-container {
   width:20px; // to force buttons to be displayed vertically
   box-shadow: 0 1px 5px rgba(0,0,0,0.65);
   border-radius: 4px;
+}
+/** we can't easily control the classes for easyButtons, but we can control
+  enabled/disabled.  Use this as a status to let us highlight the current one */
+.easy-button-button.disabled {
+  background-color: #ddd;
 }

--- a/packages/client/src/Components/Mapping/styles.scss
+++ b/packages/client/src/Components/Mapping/styles.scss
@@ -115,3 +115,9 @@ div.map-turn-marker {
 .marker-hidden {
   visibility: hidden;
 }
+
+.easy-button-container {
+  width:20px; // to force buttons to be displayed vertically
+  box-shadow: 0 1px 5px rgba(0,0,0,0.65);
+  border-radius: 4px;
+}


### PR DESCRIPTION
## 🧰 Ticket
Fixes #146 

## 🚀 Overview: 
Introduce button bar, once button per force.  Button bar only shown for white force.  Clicking on a buttons makes markers appear as they would from that force

## 🔗 Link to preview
[If you're on a project which auto-deploys branches, link to the branches preview link here]

- [x] Tests pass

## 🖥️ Screenshot
![image](https://user-images.githubusercontent.com/1108513/73614861-00c15700-45fb-11ea-8a6e-523e83480b5c.png)


## 📝 Developer Notes:
[Sometimes, extra notes are needed to add clarity to a PR, add them here]