### PR TITLE
Re-shade the planning markers aswell as current markers

### DIFF
--- a/packages/client/src/Components/Mapping/helpers/MapPlanningPlayerListener.js
+++ b/packages/client/src/Components/Mapping/helpers/MapPlanningPlayerListener.js
@@ -211,7 +211,7 @@ export default class MapPlanningPlayerListener {
   }
 
   viewAs (/* string */ force, /* layer */ allMarkers) {
-    const viewAsUmpire = !!(force === UMPIRE_FORCE)
+    const viewAsUmpire = force === UMPIRE_FORCE
     // loop through markers, updating their styling
     allMarkers.eachLayer(marker => {
       // can we see this asset?

--- a/packages/client/src/Components/Mapping/helpers/MapPlanningPlayerListener.js
+++ b/packages/client/src/Components/Mapping/helpers/MapPlanningPlayerListener.js
@@ -193,27 +193,41 @@ export default class MapPlanningPlayerListener {
     }
   }
 
+  handleMarker (/* string */ force, /* element */ marker, /* element  */ asset, /* boolean */ viewAsUmpire) {
+    const perceptionClassName = findPerceivedAsClassName(force, asset.force, asset.platformType, asset.perceptions, viewAsUmpire)
+    if (perceptionClassName) {
+      // remove existing class names
+      removeClassNamesFrom(marker, ['platform-force-', 'platform-type-'])
+
+      // set the new class names
+      L.DomUtil.addClass(marker._icon, perceptionClassName)
+
+      // reveal it, just to be sure
+      L.DomUtil.removeClass(marker._icon, 'marker-hidden')
+    } else {
+      // hide it
+      L.DomUtil.addClass(marker._icon, 'marker-hidden')
+    }
+  }
+
   viewAs (/* string */ force, /* layer */ allMarkers) {
-    const viewAsUmpire = force === UMPIRE_FORCE
+    const viewAsUmpire = !!(force === UMPIRE_FORCE)
     // loop through markers, updating their styling
     allMarkers.eachLayer(marker => {
       // can we see this asset?
       const asset = marker.asset
-      const perceptionClassName = findPerceivedAsClassName(force, marker.force, asset.platformType, asset.perceptions, viewAsUmpire)
-      if (perceptionClassName) {
-        // remove existing class names
-        removeClassNamesFrom(marker, ['platform-force-', 'platform-type-'])
+      this.handleMarker(force, marker, asset, viewAsUmpire)
+    })
 
-        // set the new class names
-        L.DomUtil.addClass(marker._icon, perceptionClassName)
-
-        // reveal it, just to be sure
-        L.DomUtil.removeClass(marker._icon, 'marker-hidden')
-      } else {
-        // hide it
-        L.DomUtil.addClass(marker._icon, 'marker-hidden')
+    // also do this for the future location markers
+    this.allRoutes.forEach(route => {
+      const marker = route.planningMarker
+      if (marker) {
+        const asset = marker.asset
+        this.handleMarker(force, marker, asset, viewAsUmpire)
       }
     })
+
     // also do this for the planning routes
     this.allRoutes.forEach(route => {
       const asset = route.asset
@@ -269,7 +283,7 @@ export default class MapPlanningPlayerListener {
       status = { state: marker.asset.status.state, speedKts: marker.asset.status.speedKts }
     } else if (marker.asset.status) {
       // we're missing a detailed status
-      const pType = marker.asset.platformTypeDetail.states.find(ptype => ptype.name ===marker.asset.status)
+      const pType = marker.asset.platformTypeDetail.states.find(ptype => ptype.name === marker.asset.status)
       status = pType
       // Note: the lower logic is expecting the status name to be
       // in a field called 'state'


### PR DESCRIPTION
Fix for adjudication stage. 

We were showing the planned location marker in the real color when in `viewAs` mode. But, this was confusing, since it should be in the perceived color