### PR TITLE
Hotfix/dont show orders panel for turn zero adjudication

### DIFF
--- a/packages/client/src/Components/Mapping/components/OrdersPanel/index.jsx
+++ b/packages/client/src/Components/Mapping/components/OrdersPanel/index.jsx
@@ -5,7 +5,7 @@ import Body from './orderContent'
 import './styles.scss'
 import { ADJUDICATION_PHASE, UMPIRE_FORCE } from '../../../../consts'
 
-const OrdersPanel = ({ selectedForce, allForces, phase, onSendClick, planningNow }) => {
+const OrdersPanel = ({ selectedForce, allForces, phase, onSendClick, planningNow, turn }) => {
   const [active, setActive] = useState(true)
 
   /** only show the orders panel if we're umpire in adjudication, or anyone in planning phase */
@@ -46,7 +46,8 @@ const OrdersPanel = ({ selectedForce, allForces, phase, onSendClick, planningNow
           selectedForce={selectedForce}
           planningNow={planningNow}
           allForces={allForces}
-          onSendClick={onSendClick} />
+          onSendClick={onSendClick}
+          turn={turn} />
         }
       </ReactCSSTransitionGroup>
     </div>

--- a/packages/client/src/Components/Mapping/components/OrdersPanel/index.jsx
+++ b/packages/client/src/Components/Mapping/components/OrdersPanel/index.jsx
@@ -11,7 +11,7 @@ const OrdersPanel = ({ selectedForce, allForces, phase, onSendClick, planningNow
   /** only show the orders panel if we're umpire in adjudication, or anyone in planning phase */
   const showOrders = () => {
     if (phase === ADJUDICATION_PHASE) {
-      return selectedForce === UMPIRE_FORCE
+      return selectedForce === UMPIRE_FORCE && turn !== 0
     } else {
       return true
     }

--- a/packages/client/src/Components/Mapping/components/OrdersPanel/index.jsx
+++ b/packages/client/src/Components/Mapping/components/OrdersPanel/index.jsx
@@ -46,8 +46,7 @@ const OrdersPanel = ({ selectedForce, allForces, phase, onSendClick, planningNow
           selectedForce={selectedForce}
           planningNow={planningNow}
           allForces={allForces}
-          onSendClick={onSendClick}
-          turn={turn} />
+          onSendClick={onSendClick} />
         }
       </ReactCSSTransitionGroup>
     </div>

--- a/packages/client/src/Components/Mapping/components/OrdersPanel/orderContent.jsx
+++ b/packages/client/src/Components/Mapping/components/OrdersPanel/orderContent.jsx
@@ -3,7 +3,7 @@ import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
 import './styles.scss'
 import OrderAsset from './orderAsset'
 
-const OrderPanelContent = ({ selectedForce, allForces, onSendClick, planningNow, turn }) => {
+const OrderPanelContent = ({ selectedForce, allForces, onSendClick, planningNow }) => {
   let selectedForceData = { assets: [] }
   const [sendVisible, setSendVisible] = useState(true)
   const inAdjudication = planningNow && planningNow.detail && planningNow.detail.type === 'StateOfWorld'
@@ -50,10 +50,7 @@ const OrderPanelContent = ({ selectedForce, allForces, onSendClick, planningNow,
     // remember this one
     setPhase(inAdjudication)
 
-    // don't show Submit button if we're in turn zero adjudication
-    if (inAdjudication && turn === 0) {
-      setSendVisible(false)
-    } else if (!sendVisible) {
+    if (!sendVisible) {
       setSendVisible(true)
     }
   }

--- a/packages/client/src/Components/Mapping/components/OrdersPanel/orderContent.jsx
+++ b/packages/client/src/Components/Mapping/components/OrdersPanel/orderContent.jsx
@@ -3,7 +3,7 @@ import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
 import './styles.scss'
 import OrderAsset from './orderAsset'
 
-const OrderPanelContent = ({ selectedForce, allForces, onSendClick, planningNow }) => {
+const OrderPanelContent = ({ selectedForce, allForces, onSendClick, planningNow, turn }) => {
   let selectedForceData = { assets: [] }
   const [sendVisible, setSendVisible] = useState(true)
   const inAdjudication = planningNow && planningNow.detail && planningNow.detail.type === 'StateOfWorld'
@@ -49,8 +49,11 @@ const OrderPanelContent = ({ selectedForce, allForces, onSendClick, planningNow 
   if (phase !== inAdjudication) {
     // remember this one
     setPhase(inAdjudication)
-    // do we need to reveal send button?
-    if (!sendVisible) {
+
+    // don't show Submit button if we're in turn zero adjudication
+    if (inAdjudication && turn === 0) {
+      setSendVisible(false)
+    } else if (!sendVisible) {
       setSendVisible(true)
     }
   }

--- a/packages/client/src/Components/Mapping/index.jsx
+++ b/packages/client/src/Components/Mapping/index.jsx
@@ -405,6 +405,7 @@ const Mapping = ({ currentTurn, role, currentWargame, selectedForce, allForces, 
         phase={phase}
         onSendClick={callbackForThisPhase()}
         planningNow={planningNow}
+        turn={currentTurn}
       />
       <div id="map" className="mapping"/>
     </div>


### PR DESCRIPTION
The game logic will break if the umpire tries to submit state of the world in turn zero.  Prevent that happening.