### PR TITLE
Feature/multi input suite

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@babel/core": "^7.8.4",
     "@material-ui/core": "^4.9.2",
+    "@material-ui/icons": "^4.9.1",
     "@serge/custom-types": "0.3.0",
     "@serge/helpers": "0.3.0",
     "@serge/mocks": "0.3.0",

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -5,3 +5,5 @@
  */
 
 export { default as ProgressIndicator } from './local/progress-indicator'
+export { default as InputContainer } from './local/input-container'
+export { default as DialogueHeader } from './local/dialogue-header'

--- a/packages/components/src/vendor/md-button-group/README.md
+++ b/packages/components/src/vendor/md-button-group/README.md
@@ -1,0 +1,22 @@
+# Button Group (from Material Design)
+
+The `ButtonGroup` component is a third-party component from the Material-UI library. 
+
+For more information on this component, please visit: https://material-ui.com/components/button-group/
+
+## UI Example
+
+<!-- STORY -->
+
+## Usage
+
+### ES6 Import
+```js
+import ButtonGroup from '@material-ui/core/ButtonGroup'
+```
+
+### CommonJS
+
+```js
+const ButtonGroup = require('@material-ui/core/ButtonGroup')
+```

--- a/packages/components/src/vendor/md-button-group/index.stories.tsx
+++ b/packages/components/src/vendor/md-button-group/index.stories.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+
+// Import component files
+import { ButtonGroup, Button } from '@material-ui/core'
+import { Home, Language, HourglassFull } from '@material-ui/icons';
+
+import docs from './README.md'
+
+export default {
+  title: 'vendor/ButtonGroup',
+  component: ButtonGroup,
+  parameters: {
+    readme: {
+      // Show readme before story
+      content: docs
+    }
+  }
+}
+
+const items = [
+  {
+    name: 'Button 1',
+    value: 'button-1'
+  },
+  {
+    name: 'Button 2',
+    value: 'button-2'
+  },
+  {
+    name: 'Button 3',
+    value: 'button-3'
+  }
+]
+
+const buttons = items.map(option => <Button key={option.value} value={option.value}>{option.name}</Button>)
+
+export const Default: React.FC = () => <ButtonGroup orientation="vertical" color="primary"aria-label="vertical outlined primary button group">{buttons}</ButtonGroup>
+export const Icons: React.FC = () => <ButtonGroup orientation="vertical" color="primary"aria-label="vertical outlined primary button group">
+  <Button>
+    <Home />
+  </Button>
+  <Button>
+    <Language />
+  </Button>
+  <Button>
+    <HourglassFull />
+  </Button>
+</ButtonGroup>

--- a/packages/components/src/vendor/md-button/README.md
+++ b/packages/components/src/vendor/md-button/README.md
@@ -1,6 +1,6 @@
 # Button (from Material Design)
 
-The `button` component is a third party component from the Material-UI library. 
+The `button` component is a third-party component from the Material-UI library. 
 
 For more information on this component, please visit: https://material-ui.com/components/buttons/
 

--- a/packages/components/src/vendor/md-checbox/README.md
+++ b/packages/components/src/vendor/md-checbox/README.md
@@ -1,6 +1,6 @@
 # Checkbox (from Material Design)
 
-The `checkbox` component is a third party component from the Material-UI library. 
+The `checkbox` component is a third-party component from the Material-UI library. 
 
 For more information on this component, please visit: https://material-ui.com/components/checkbox/
 

--- a/packages/components/src/vendor/md-chip/README.md
+++ b/packages/components/src/vendor/md-chip/README.md
@@ -1,6 +1,6 @@
 # Chip (from Material Design)
 
-The `chip` component is a third party component from the Material-UI library. 
+The `chip` component is a third-party component from the Material-UI library. 
 
 For more information on this component, please visit: https://material-ui.com/components/chips/
 

--- a/packages/components/src/vendor/md-radio/README.md
+++ b/packages/components/src/vendor/md-radio/README.md
@@ -1,6 +1,6 @@
 # Radio (from Material Design)
 
-The `radio` component is a third party component from the Material-UI library. 
+The `radio` component is a third-party component from the Material-UI library. 
 
 For more information on this component, please visit: https://material-ui.com/components/radio/
 

--- a/packages/components/src/vendor/md-select/README.md
+++ b/packages/components/src/vendor/md-select/README.md
@@ -1,0 +1,22 @@
+# Select (from Material Design)
+
+The `Select` component is a third-party component from the Material-UI library. 
+
+For more information on this component, please visit: https://material-ui.com/components/selects/
+
+## UI Example
+
+<!-- STORY -->
+
+## Usage
+
+### ES6 Import
+```js
+import Select from '@material-ui/core/Select'
+```
+
+### CommonJS
+
+```js
+const Select = require('@material-ui/core/Select')
+```

--- a/packages/components/src/vendor/md-select/index.stories.tsx
+++ b/packages/components/src/vendor/md-select/index.stories.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+
+// Import component files
+import {Select, MenuItem, InputLabel} from '@material-ui/core'
+import { InputContainer } from '../../index'
+
+import docs from './README.md'
+
+export default {
+  title: 'vendor/Select',
+  component: Select,
+  parameters: {
+    readme: {
+      // Show readme before story
+      content: docs
+    }
+  }
+}
+
+const items = [
+  {
+    name: 'Item 1',
+    value: 'item-1'
+  },
+  {
+    name: 'Item 2',
+    value: 'item-2'
+  },
+  {
+    name: 'Item 3',
+    value: 'item-3'
+  }
+]
+
+const options = items.map(option => <MenuItem key={option.value} value={option.value}>{option.name}</MenuItem>)
+
+export const Default: React.FunctionComponent = () => <Select value="item-1">{options}</Select>
+export const WithLabel: React.FunctionComponent = () => <InputContainer><InputLabel id="select-id">Item selector</InputLabel><Select value="item-1" id="Select" labelId="select-id" name="Select" label="Example">{options}</Select></InputContainer>
+export const WithError: React.FunctionComponent = () => <Select value="item-1" id="Select" name="Select" label="Example" error>{options}</Select>
+export const ReadOnly: React.FunctionComponent = () => <Select value="item-1" id="Select" name="Select" label="Example">{options}</Select>
+export const Disabled: React.FunctionComponent = () => <Select value="item-1" disabled>{options}</Select>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2248,6 +2248,13 @@
     react-is "^16.8.0"
     react-transition-group "^4.3.0"
 
+"@material-ui/icons@^4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.9.1.tgz#fdeadf8cb3d89208945b33dbc50c7c616d0bd665"
+  integrity sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
 "@material-ui/styles@^4.9.0":
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.9.0.tgz#10c31859f6868cfa9d3adf6b6c3e32c9d676bc76"


### PR DESCRIPTION
## 🧰 Issue
Closes #345 
Closes #344 
Closes #341 
Closes #340 
Closes #339 
Closes #338 
Closes #337 
Closes #349 

## 🚀 Overview: 
Adds multiple Material UI elements to allow for the building of form components

## 🔗 Link to preview
https://deploy-preview-360--serge-storybook.netlify.com/

## 🤔 Reason: 
[Material UI](https://material-ui.com/) is a react component library based on Google's [Material Design](https://material.io/) system. It contains many off-the-shelf components which we can easily integrate into the Serge project. This makes a start of adding some of the most useful ones.

## 🔨Work carried out:

- [x] Added stories for all components (Button, ButtonGroup, Checkbox, Radio, Text/Number Input, Select, InputLabel)
- [x] Storybook builds

## 🖥️ Screenshot

![2020-04-07 15 02 26](https://user-images.githubusercontent.com/151028/78678681-3297b800-78e1-11ea-8fbb-bdb1fcc9880c.gif)

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have assigned myself to this PR.
- [x] I have chosen an appropriate label for the PR.
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
- [x] I confirm that I have checked for required README updates and acted accordingly.

## 📝 Developer Notes:

- Custom styling has not been added for the material design components as yet. This should be done in the `themes` package.



