### PR TITLE
Feature/374 choose dialog for asset click

### DIFF
--- a/packages/components/src/local/mapping/helpers/asset-dialog-for.spec.ts
+++ b/packages/components/src/local/mapping/helpers/asset-dialog-for.spec.ts
@@ -1,0 +1,31 @@
+/* global it expect */
+import assetDialogFor from './asset-dialog-for'
+import Phase from '../types/phases'
+
+it('provides the correct when planning my force', () => {
+  expect(assetDialogFor('Blue', 'Blue', [], Phase.Planning)).toEqual('Planning')
+})
+
+it('provides the correct when planning other force', () => {
+  expect(assetDialogFor('Blue', 'Red', [], Phase.Planning)).toEqual('PerceivedAs')
+})
+
+it('provides the correct when planning other force I can control', () => {
+  expect(assetDialogFor('Umpire', 'Blue', ['Umpire'], Phase.Planning)).toEqual('Planning')
+})
+
+it('provides the correct when planning other force umpire cant control', () => {
+  expect(assetDialogFor('Umpire', 'Blue', [], Phase.Planning)).toEqual('')
+})
+
+it('provides the correct when click my force in adjudication', () => {
+  expect(assetDialogFor('Blue', 'Blue', [], Phase.Adjudication)).toEqual('')
+})
+
+it('provides the correct when click my force in adjudication', () => {
+  expect(assetDialogFor('Blue', 'Red', [], Phase.Adjudication)).toEqual('PerceivedAs')
+})
+
+it('provides the correct when umpire clicks on any platform in adjudication', () => {
+  expect(assetDialogFor('Umpire', 'Red', [], Phase.Adjudication)).toEqual('Adjudication')
+})

--- a/packages/components/src/local/mapping/helpers/asset-dialog-for.ts
+++ b/packages/components/src/local/mapping/helpers/asset-dialog-for.ts
@@ -1,0 +1,39 @@
+import Phase from '../types/phases'
+
+/** determine which form to show on this click
+ * @param {string} playerForce the force for the current player
+ * @param {string} assetForce the force for the selected asset
+ * @param {string} assetControlledBy which forces can control this asset
+ * @param {Phase} gamePhase the name of the current game phase
+ * @return {string} name of dialog to show
+ */
+const assetDialogFor = (playerForce:string, assetForce:string, assetControlledBy: [string?], 
+  gamePhase: Phase): string => {
+    let res: string = ''
+    switch(gamePhase)
+    {
+      case Phase.Planning:
+        if (assetForce === playerForce) {
+          res = "Planning"
+        } else if (assetControlledBy != null && assetControlledBy.includes(playerForce)) {
+          res = "Planning"
+        } else if(playerForce !== 'Umpire') {
+          res = "PerceivedAs"
+        } else {
+          res = ''
+        }
+        break;
+      case Phase.Adjudication:
+        if (playerForce === 'Umpire') {
+          res = "Adjudication"
+        } else if (assetForce !== playerForce) {
+          res = "PerceivedAs"
+        } else {
+          res = ''
+        }
+        break;      
+    }
+    return res
+}
+
+export default assetDialogFor

--- a/packages/components/src/local/mapping/types/phases.d.ts
+++ b/packages/components/src/local/mapping/types/phases.d.ts
@@ -1,3 +1,6 @@
+/**
+ * list the possible phases in a wargame
+ */
 enum Phase {
   /* players are planning their next turn
    */

--- a/packages/components/src/local/mapping/types/phases.d.ts
+++ b/packages/components/src/local/mapping/types/phases.d.ts
@@ -1,0 +1,8 @@
+enum Phase {
+  /* players are planning their next turn
+   */
+  Planning = "Planning",
+  /** umpire is resolving planned turns */
+  Adjudication = "Adjudication"
+}
+export default Phase


### PR DESCRIPTION
<!-- 
Please ensure that you complete the following mandatory sections:

- Issue*
- Overview
- Reason*
- Work carried out
- Confirmations

* Only mandatory if working from a issue
 -->

## 🧰 Issue
<!-- [The issue the work was done for as an issue reference (e.g. `closes #1`)] -->
Fixes issue #374 


## 🚀 Overview: 
<!-- [A summary of what you did in no more than one paragraph] -->
When clicking on an asset, different forms are displayed in different circumstances.

This PR introduces a non-UI helper function that indicates which form to be displayed in which circumstances.

## 🔗 Link to preview
<!-- [If you're on a project which auto-deploys branches, link to the branches preview link here] -->
Nothing to see, it's just the unit test that drives it.

## 🤔 Reason: 
<!-- [Why did you do what you did? - This should be copied from the User Story part of the issue if it is available] -->

To ensure preparatory work is ready prior to UI steps

## 🔨Work carried out:

* [x] Capture the logic presented in #374 
* [x] Test above logic

<!-- [A list of work you have done, use [markdown checklist format](https://github.blog/2013-01-09-task-lists-in-gfm-issues-pulls-comments/), if you leave any boxes unchecked, be sure to leave this PR as a draft. If the issue has Acceptance Criteria, you should include those items to show that you have accomplished the goals of the issue ] -->

- [x] Tests pass

## Confirmations

- [*] I have chosen reviewers for my PR.
- [*] I have assigned myself to this PR.
- [*] I have chosen an appropriate label for the PR.
- [*] I have completed the mandatory sections of this document.
- [*] I have deleted any unused sections.
- [*] I confirm that I have checked for required README updates and acted accordingly.

