### PR TITLE
add map ref for childrens and hide/show grid coords on zoomend

### DIFF
--- a/packages/components/src/local/asset-icon/index.tsx
+++ b/packages/components/src/local/asset-icon/index.tsx
@@ -14,23 +14,23 @@ import { MapContext } from '../mapping'
 import assetDialogFor from '../mapping/helpers/asset-dialog-for'
 
 /* Render component */
-export const AssetIcon: React.FC<PropTypes> = ({ position, type, force, tooltip, controlledBy, selected }) => 
+export const AssetIcon: React.FC<PropTypes> = ({ position, type, force, tooltip, controlledBy, selected }) =>
   <MapContext.Consumer>
     {
       (context): React.ReactNode => {
         const divIcon = L.divIcon({
           iconSize: [40, 40],
-          className: cx(styles['asset-icon'], styles[force], 
+          className: cx(styles['asset-icon'], styles[force],
             selected ? styles[`selected`]:null, styles[`platform-type-${type}`])
         })
-      
+
         const clickEvent = (): void => {
           const form = assetDialogFor(context.props.playerForce, force, controlledBy, context.props.phase)
           console.log(form)
           context.props.setCurrentForm(form)
           context.props.setShowMapBar(true)
         }
-      
+
         return <Marker position={position} icon={divIcon} onclick={clickEvent}>
           <Tooltip>{tooltip}</Tooltip>
         </Marker>

--- a/packages/components/src/local/hex-grid/index.tsx
+++ b/packages/components/src/local/hex-grid/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import React, { ReactNode, useState } from 'react'
 import L from 'leaflet'
 import { PointLike } from 'honeycomb-grid'
 import { Polygon, Marker, LayerGroup } from 'react-leaflet'
@@ -12,8 +12,18 @@ import { MapContext } from '../mapping'
 import SergeHex from '../mapping/types/serge-hex'
 
 /* Render component */
-export const HexGrid: React.FC<PropTypes> = ({ gridCells }: PropTypes) =>
-  <MapContext.Consumer>
+export const HexGrid: React.FC<PropTypes> = ({ gridCells, mapRef }: PropTypes) => {
+
+  const [showCoords, setShowCoords] = useState(false)
+  // only show the markers when zoomed in
+  if (mapRef && mapRef.current.leafletElement) {
+    mapRef.current.leafletElement.on('zoomend', () => {
+      setShowCoords(mapRef.current.leafletElement.getZoom() >= 11)
+    })
+  }
+
+  return (
+    <MapContext.Consumer>
     { (context): ReactNode => {
       // collate list of named polygons
       const polygons: { [id: string]: L.LatLng[] } = {}
@@ -58,21 +68,26 @@ export const HexGrid: React.FC<PropTypes> = ({ gridCells }: PropTypes) =>
           />
         ))}
         </LayerGroup>
-        <LayerGroup key={'hex_labels'} >{Object.keys(centres).map(k => (
-          <Marker
-            key = {'hex_label_' + k}
-            position={centres[k]}
-            width="120"
-            icon={L.divIcon({
-              html: k,
-              className: styles['default-coords'],
-              iconSize: [30, 20]
-            })}
-          />
-        ))}
-        </LayerGroup>
+        {showCoords &&
+          <LayerGroup key={'hex_labels'} >{Object.keys(centres).map(k => (
+            <Marker
+              key = {'hex_label_' + k}
+              position={centres[k]}
+              width="120"
+              icon={L.divIcon({
+                html: k,
+                className: styles['default-coords'],
+                iconSize: [30, 20]
+              })}
+            />
+          ))}
+          </LayerGroup>
+        }
       </>
     }}
   </MapContext.Consumer>
+)
+}
+
 
 export default HexGrid

--- a/packages/components/src/local/hex-grid/index.tsx
+++ b/packages/components/src/local/hex-grid/index.tsx
@@ -16,7 +16,7 @@ export const HexGrid: React.FC<PropTypes> = ({ gridCells, mapRef }: PropTypes) =
 
   const [showCoords, setShowCoords] = useState(false)
   // only show the markers when zoomed in
-  if (mapRef && mapRef.current.leafletElement) {
+  if (mapRef && mapRef.current && mapRef.current.leafletElement) {
     mapRef.current.leafletElement.on('zoomend', () => {
       setShowCoords(mapRef.current.leafletElement.getZoom() >= 11)
     })

--- a/packages/components/src/local/hex-grid/index.tsx
+++ b/packages/components/src/local/hex-grid/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react'
+import React, { ReactNode } from 'react'
 import L from 'leaflet'
 import { PointLike } from 'honeycomb-grid'
 import { Polygon, Marker, LayerGroup } from 'react-leaflet'
@@ -12,18 +12,8 @@ import { MapContext } from '../mapping'
 import SergeHex from '../mapping/types/serge-hex'
 
 /* Render component */
-export const HexGrid: React.FC<PropTypes> = ({ gridCells, mapRef }: PropTypes) => {
-
-  const [showCoords, setShowCoords] = useState(false)
-  // only show the markers when zoomed in
-  if (mapRef && mapRef.current && mapRef.current.leafletElement) {
-    mapRef.current.leafletElement.on('zoomend', () => {
-      setShowCoords(mapRef.current.leafletElement.getZoom() >= 11)
-    })
-  }
-
-  return (
-    <MapContext.Consumer>
+export const HexGrid: React.FC<PropTypes> = ({ gridCells }: PropTypes) =>
+  <MapContext.Consumer>
     { (context): ReactNode => {
       // collate list of named polygons
       const polygons: { [id: string]: L.LatLng[] } = {}
@@ -68,7 +58,8 @@ export const HexGrid: React.FC<PropTypes> = ({ gridCells, mapRef }: PropTypes) =
           />
         ))}
         </LayerGroup>
-        {showCoords &&
+        {
+          context.props.zoomLevel > 11 &&
           <LayerGroup key={'hex_labels'} >{Object.keys(centres).map(k => (
             <Marker
               key = {'hex_label_' + k}
@@ -86,8 +77,5 @@ export const HexGrid: React.FC<PropTypes> = ({ gridCells, mapRef }: PropTypes) =
       </>
     }}
   </MapContext.Consumer>
-)
-}
-
 
 export default HexGrid

--- a/packages/components/src/local/hex-grid/types/props.d.ts
+++ b/packages/components/src/local/hex-grid/types/props.d.ts
@@ -6,5 +6,4 @@ export default interface PropTypes {
    * the grid of hex cells
    */
   gridCells?: SergeGrid<SergeHex<{}>>
-  mapRef?: any
 }

--- a/packages/components/src/local/hex-grid/types/props.d.ts
+++ b/packages/components/src/local/hex-grid/types/props.d.ts
@@ -6,4 +6,5 @@ export default interface PropTypes {
    * the grid of hex cells
    */
   gridCells?: SergeGrid<SergeHex<{}>>
+  mapRef?: any
 }

--- a/packages/components/src/local/mapping/index.tsx
+++ b/packages/components/src/local/mapping/index.tsx
@@ -1,5 +1,5 @@
 import L from 'leaflet'
-import React, { createContext, useState } from 'react'
+import React, { createContext, useState, createRef, cloneElement, Children, isValidElement, ReactElement } from 'react'
 import { Map, TileLayer, ScaleControl } from 'react-leaflet'
 import createGrid from './helpers/createGrid'
 import SergeHex from './types/serge-hex'
@@ -81,6 +81,7 @@ export const Mapping: React.FC<PropTypes> = ({
   const bottomRight = L.latLng(imageBottom, imageRight)
   const latLngBounds: L.LatLngBounds = L.latLngBounds(topLeft, bottomRight)
   const gridCells: SergeGrid<SergeHex<{}>> = createGrid(latLngBounds, tileDiameterMins)
+  const mapRef = createRef<any>();
 
   // Anything you put in here will be available to any child component of Map via a context consumer
   const contextProps: MappingContext = {
@@ -93,6 +94,10 @@ export const Mapping: React.FC<PropTypes> = ({
     currentForm,
     setCurrentForm
   }
+
+  const childrenWithProps = Children.map(children, child =>
+    isValidElement(child) ? cloneElement(child as ReactElement<any>, { mapRef }) : child
+  )
 
   return (
   <MapContext.Provider value={{ props: contextProps }}>
@@ -109,6 +114,7 @@ export const Mapping: React.FC<PropTypes> = ({
         minZoom={minZoom}
         zoomControl={zoomControl}
         maxZoom={maxZoom}
+        ref={mapRef}
         touchZoom={touchZoom}
         zoomAnimation={zoomAnimation}
         attributionControl={attributionControl}
@@ -119,7 +125,7 @@ export const Mapping: React.FC<PropTypes> = ({
           bounds={latLngBounds}
         />
         <ScaleControl/>
-          {children}
+           {childrenWithProps}
       </Map>
     </section>
   </MapContext.Provider>

--- a/packages/components/src/local/mapping/types/mapping-context.d.ts
+++ b/packages/components/src/local/mapping/types/mapping-context.d.ts
@@ -2,11 +2,11 @@ import { Phase } from '@serge/config'
 import SergeHex from './serge-hex'
 import SergeGrid from './serge-grid'
 
-/** 
+/**
  * mapping context, shared with child elements
  */
 export default interface MappingContext {
-  /** 
+  /**
    * grid of cells, used for movement
    */
   gridCells: SergeGrid<SergeHex<{}>>
@@ -14,23 +14,23 @@ export default interface MappingContext {
    * list of forces within this wargame
    */
   forces: any
-  /** 
+  /**
    * force for current player
-   */ 
+   */
   playerForce: string
   /**
    * phase of current game
    */
   phase: Phase
-  /** 
-   * state for if map bar is open 
+  /**
+   * state for if map bar is open
    */
   showMapBar: boolean
   /**
    *  setter, to modify if map bar is open or not
    */
   setShowMapBar: React.Dispatch<React.SetStateAction<boolean>>
-  /** 
+  /**
    * state for which form should appear in the map bar
    */
   currentForm: string
@@ -38,5 +38,12 @@ export default interface MappingContext {
    *  setter, to modify the form display in map bar
    **/
   setCurrentForm: React.Dispatch<React.SetStateAction<string>>
+  /**
+   *  state for zoom Level
+   **/
+  zoomLevel: number
+  /**
+   *  setter, to set the zoom level
+   **/
+  setZoomLevel: React.Dispatch<React.SetStateAction<number>>
 }
-

--- a/packages/components/src/local/mapping/types/props.d.ts
+++ b/packages/components/src/local/mapping/types/props.d.ts
@@ -14,20 +14,20 @@ export default interface PropTypes {
     imageRight: number
     imageBottom: number
   }
-  /** 
+  /**
    * diameter of tiles in use
    */
   tileDiameterMins: number
   /** forces for this wargame
-   * 
+   *
    */
   forces: any,
-  /** current player's force 
-   * 
+  /** current player's force
+   *
   */
   playerForce: string,
-  /** current player's force 
-   * 
+  /** current player's force
+   *
   */
   phase: Phase,
  /**
@@ -89,5 +89,5 @@ export default interface PropTypes {
    * @default false
    */
   zoomAnimation?: boolean
-
+  children?: any
 }

--- a/packages/components/src/local/mapping/types/props.d.ts
+++ b/packages/components/src/local/mapping/types/props.d.ts
@@ -89,5 +89,4 @@ export default interface PropTypes {
    * @default false
    */
   zoomAnimation?: boolean
-  children?: any
 }


### PR DESCRIPTION
## 🧰 Issue
closes #377


## 🚀 Overview: 
<!-- [A summary of what you did in no more than one paragraph] -->

## 🔗 Link to preview
<!-- [If you're on a project which auto-deploys branches, link to the branches preview link here] -->
https://deploy-preview-393--serge-storybook.netlify.app/

## 🤔 Reason: 
I dont like the beta package https://github.com/auto-mat/leaflet-zoom-show-hide
So I think the "The 'legacy' way of doing this" is more suitable.
I had done the function with one can forward some props to child component, and for Mapping component childrens I had added mapRef variable (P.S.: I am not able to get it works with standar react ref types and had used `any` type) 

## 🖥️ Screenshot
I had found some issues connected with coords 
P.S this screenshot was done before the issue was fixed.

![2020-04-24_12-41-14](https://user-images.githubusercontent.com/20753599/80206838-1f554e00-863e-11ea-869c-c43d2a0fd134.png)


