### PR TITLE
403 - Introduce planned route rendering

### DIFF
--- a/packages/components/src/local/hex-grid/styles.module.scss
+++ b/packages/components/src/local/hex-grid/styles.module.scss
@@ -6,11 +6,21 @@
 }
 
 .allowable-hex {
-  fill: true;
-  color: #ccc;
+  fill: #ccc;
   stroke: #fff;
   opacity: 1;
   stroke-width: 2;
+}
+
+.planned-hex {
+  fill: #249;
+  stroke: #fff;
+  opacity: 1;
+  stroke-width: 2;
+}
+
+.planned-line {
+  stroke: #249;
 }
 
 .default-coords {

--- a/packages/components/src/local/hex-grid/styles.module.scss.d.ts
+++ b/packages/components/src/local/hex-grid/styles.module.scss.d.ts
@@ -4,6 +4,8 @@ interface CssExports {
   'allowable-hex': string;
   'default-coords': string;
   'default-hex': string;
+  'planned-hex': string;
+  'planned-line': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/packages/components/src/local/mapping/helpers/planned-route-for.ts
+++ b/packages/components/src/local/mapping/helpers/planned-route-for.ts
@@ -1,0 +1,27 @@
+import SergeHex from '../types/serge-hex'
+import SergeGrid from '../types/serge-grid'
+
+/**
+ *  create hexagonal grid
+ * @param {SergeGrid<SergeHex<{}>>} grid grid of hex cells
+ * @param {PlanMobileAsset} constraints Description of what this platform can do
+ * @returns {string[]} List of cell names
+ */
+const plannedRouteFor = (grid: SergeGrid<SergeHex<{}>>, allowableCells:string[] | undefined, origin:string, destination: string): string[] | undefined => {
+  const originHex: SergeHex<{}> | undefined = grid.find(cell => cell.name === origin)
+  const destinationHex: SergeHex<{}> | undefined = grid.find(cell => cell.name === destination)
+  if(originHex && destinationHex) {
+    var route = grid.hexesBetween(originHex, destinationHex)
+    if(allowableCells) {
+      // sort out overlap with allowable cells
+      route = route.filter(cell => allowableCells.includes(cell.name))
+    }
+    // convert to string array
+    const res: string[] = route.map(cell => cell.name)
+    return res
+  } else {
+    return undefined
+  }
+}
+
+export default plannedRouteFor

--- a/packages/components/src/local/mapping/index.stories.tsx
+++ b/packages/components/src/local/mapping/index.stories.tsx
@@ -214,6 +214,9 @@ const allowableGridOptions = {
   step: 1
 }
 
+const allowableDestinationLabel = 'Destination'
+const allowableDestinationValue = 'F10'
+
 export const WithAllowableRange: React.FC = () => <Mapping
   bounds = {bounds}
   tileLayer = {LocalTileLayer}
@@ -225,7 +228,9 @@ export const WithAllowableRange: React.FC = () => <Mapping
   planningConstraints={ boolean(allowableOnLabel, allowableDefaultValue) ? {
     origin:text(allowableOriginLabel, allowableOriginValue), 
     travelMode:radios(allowableTerrain, allowableTerrainOptions, allowableTerrainDefault,), 
-    range:number(allowableGridLabel, allowableGridDefaultValue, allowableGridOptions) } : undefined}
+    range:number(allowableGridLabel, allowableGridDefaultValue, allowableGridOptions),
+    destination:text(allowableDestinationLabel, allowableDestinationValue)
+   } : undefined}
   >
   <HexGrid />
 </Mapping>

--- a/packages/components/src/local/mapping/index.tsx
+++ b/packages/components/src/local/mapping/index.tsx
@@ -16,6 +16,7 @@ import MappingContext from './types/mapping-context'
 import MapBar from '../map-bar'
 
 import allowableCells from './helpers/allowable-cells'
+import plannedRouteFor from './helpers/planned-route-for'
 
 interface ContextInterface {
   props?: any
@@ -93,6 +94,8 @@ export const Mapping: React.FC<PropTypes> = ({
   const latLngBounds: L.LatLngBounds = L.latLngBounds(topLeft, bottomRight)
   const gridCells: SergeGrid<SergeHex<{}>> = createGrid(latLngBounds, tileDiameterMins)
   const allowableCellList = planningConstraints ? allowableCells(gridCells, planningConstraints) : undefined
+  const plannedRouteList = planningConstraints && planningConstraints.destination ? 
+    plannedRouteFor(gridCells, allowableCellList, planningConstraints.origin, planningConstraints.destination) : undefined
 
   // Anything you put in here will be available to any child component of Map via a context consumer
   const contextProps: MappingContext = {
@@ -101,6 +104,7 @@ export const Mapping: React.FC<PropTypes> = ({
     playerForce,
     phase,
     allowableCellList,
+    plannedRouteList,
     showMapBar,
     setShowMapBar,
     selectedAsset,

--- a/packages/components/src/local/mapping/types/mapping-context.d.ts
+++ b/packages/components/src/local/mapping/types/mapping-context.d.ts
@@ -50,6 +50,10 @@ export default interface MappingContext {
    **/
   allowableCellList?: string[] | undefined
   /**
+   *  allowable cells for this platform
+   **/
+  plannedRouteList?: string[] | undefined
+  /**
    * state for if map bar is open
    */
   showMapBar: boolean

--- a/packages/components/src/local/mapping/types/plan-mobile-asset.ts
+++ b/packages/components/src/local/mapping/types/plan-mobile-asset.ts
@@ -14,4 +14,8 @@ export default interface PlanMobileAsset {
    * mode of travel for this asset
    */
   travelMode: string
+  /** 
+   * current destination of route being planned
+   */
+  destination: string
 }


### PR DESCRIPTION
<!-- 
Please ensure that you complete the following mandatory sections:

- Issue*
- Overview
- Reason*
- Work carried out
- Confirmations

* Only mandatory if working from a issue
 -->

## 🧰 Issue
<!-- [The issue the work was done for as an issue reference (e.g. `closes #1`)] -->
Fixes #402 

## 🚀 Overview: 
<!-- [A summary of what you did in no more than one paragraph] -->
Displays a line (& filled hexes) to show the path of the route that's currently being planned.

## 🔗 Link to preview
<!-- [If you're on a project which auto-deploys branches, link to the branches preview link here] -->
https://deploy-preview-404--serge-storybook.netlify.app/?path=/story/local-mapping--with-allowable-range

## 🤔 Reason: 
<!-- [Why did you do what you did? - This should be copied from the User Story part of the issue if it is available] -->

## 🔨Work carried out:

* [x] create new structure, to store cells that represent new route
* [x] change hex styling test, to verify if cells are part of planned route, before checking if they're part of available cells
* [x] collate polygon centres, to be plotted as line
- [x] Tests pass

## 🖥️ Screenshot
<!-- [If the work is UI related then paste a screenshot of the update here. Where possible, please use an animated screenshot.] -->

![PlannedAnimation](https://user-images.githubusercontent.com/1108513/80496573-49ba4a80-8961-11ea-99a3-bc0af3121423.gif)

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have assigned myself to this PR.
- [x] I have chosen an appropriate label for the PR.
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
- [x] I confirm that I have checked for required README updates and acted accordingly.

## 📝 Developer Notes:
<!-- [Sometimes, extra notes are needed to add clarity to a PR, add them here] -->

There may be some performance inefficiencies in this PR, related to switching between representing hexes as honeycomb-hexes, and as plain strings.  That will be investigated in another PR.