### PR TITLE
fix polygon render on classname change

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "component-build": "lerna run build --scope @serge/components --stream",
     "component-dev": "yarn component-build & lerna run watch --parallel --scope @serge/components",
     "diff": "lerna diff",
-    "heroku-postbuild": "yarn build",
+    "heroku-postbuild": "yarn build && yarn build-storybook",
     "serge": "yarn start-server",
     "snyk-protect": "export NODE_OPTIONS=–max_old_space_size=8192 snyk protect",
     "prepare": "yarn run snyk-protect",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -15,8 +15,8 @@
     "test:unit": "jest --coverage",
     "lint": "run-p lint:*",
     "lint:ts": "eslint --fix src/**/*.ts*",
-    "lint:styles": "stylelint src/**/*.scss",
-    "build-storybook": "build-storybook -s ./static -c .storybook -o .out"
+    "lint:styles": "stylelint --fix src/**/*.scss",
+    "build-storybook": "build-storybook -s ./static -c .storybook -o ../client/build/storybook"
   },
   "dependencies": {
     "@babel/core": "^7.8.4",

--- a/packages/components/src/local/hex-grid/helpers/polygon.ts
+++ b/packages/components/src/local/hex-grid/helpers/polygon.ts
@@ -1,0 +1,46 @@
+import { Path, withLeaflet } from 'react-leaflet'
+import type { LatLng, PathProps, PolylineProps } from 'react-leaflet'
+import { Polygon as LeafletPolygon } from 'leaflet'
+import { difference } from 'lodash'
+
+// uodate LeafletPolygon class to be able to covert it to LeafletElementtype
+class LeafletPolygonWithPositions extends LeafletPolygon {
+  positions = []
+}
+
+// define props
+type Props = {
+  positions: LatLng[] | LatLng[][] | LatLng[][][],
+} & PathProps & any
+
+// Leaflet element PathProps & PolylineProps required props for Path class
+type LeafletElement = PathProps & PolylineProps
+
+// create custom polygon class
+class Polygon extends Path<LeafletElement, Props> {
+
+  // create leaflet element and add it in to html (copied from standard leaflet polygon)
+  createLeafletElement(props: Props): LeafletElement {
+    return new LeafletPolygonWithPositions(props.positions, this.getOptions(props)) as LeafletElement
+  }
+
+  // this function will allow to add logick to update element
+  updateLeafletElement(fromProps: Props, toProps: Props) {
+    // update the component on positions change (copied from standard leaflet polygon)
+    if (toProps.positions !== fromProps.positions) {
+      this.leafletElement.setLatLngs(toProps.positions)
+    }
+    this.setStyleIfChanged(fromProps, toProps)
+
+    // logick wich one will compare classnames and modify the element class attribute instead of re render it
+    // this will alow to not touch elements witch ones have no changes in classname
+    if (toProps.className !== fromProps.className) {
+      const fromClasses: string[] = fromProps.className.split(' ')
+      const toClasses: string[] = toProps.className.split(' ')
+      this.leafletElement._path.classList.remove(...difference(fromClasses, toClasses))
+      this.leafletElement._path.classList.add(...difference(toClasses, fromClasses))
+    }
+  }
+}
+
+export default withLeaflet<Props>(Polygon)

--- a/packages/components/src/local/hex-grid/helpers/polygon.ts
+++ b/packages/components/src/local/hex-grid/helpers/polygon.ts
@@ -24,7 +24,7 @@ class Polygon extends Path<LeafletElement, Props> {
     return new LeafletPolygonWithPositions(props.positions, this.getOptions(props)) as LeafletElement
   }
 
-  // this function will allow to add logic to update element
+  // reduce re-rendering, by only updating changed elemente
   updateLeafletElement(fromProps: Props, toProps: Props) {
     // update the component on positions change (copied from standard leaflet polygon)
     if (toProps.positions !== fromProps.positions) {
@@ -32,8 +32,7 @@ class Polygon extends Path<LeafletElement, Props> {
     }
     this.setStyleIfChanged(fromProps, toProps)
 
-    // logick wich one will compare classnames and modify the element class attribute instead of re render it
-    // this will alow to not touch elements witch ones have no changes in classname
+    // check classname
     if (toProps.className !== fromProps.className) {
       const fromClasses: string[] = fromProps.className.split(' ')
       const toClasses: string[] = toProps.className.split(' ')

--- a/packages/components/src/local/hex-grid/helpers/polygon.ts
+++ b/packages/components/src/local/hex-grid/helpers/polygon.ts
@@ -24,7 +24,7 @@ class Polygon extends Path<LeafletElement, Props> {
     return new LeafletPolygonWithPositions(props.positions, this.getOptions(props)) as LeafletElement
   }
 
-  // this function will allow to add logick to update element
+  // this function will allow to add logic to update element
   updateLeafletElement(fromProps: Props, toProps: Props) {
     // update the component on positions change (copied from standard leaflet polygon)
     if (toProps.positions !== fromProps.positions) {

--- a/packages/components/src/local/hex-grid/index.tsx
+++ b/packages/components/src/local/hex-grid/index.tsx
@@ -1,19 +1,20 @@
 import React, { useEffect, useState, useContext} from 'react'
 import L from 'leaflet'
 import { PointLike } from 'honeycomb-grid'
-import { Polygon, Marker, LayerGroup, Polyline } from 'react-leaflet'
+import { Marker, LayerGroup, Polyline } from 'react-leaflet'
 /* Import Stylesheet */
 import styles from './styles.module.scss'
 
 /* Import Types */
 import PropTypes from './types/props'
 import toWorld from './helpers/to-world'
+import Polygon from './helpers/polygon'
 import { MapContext } from '../mapping'
 import SergeHex from '../mapping/types/serge-hex'
 
 /* Render component */
 export const HexGrid: React.FC<PropTypes> = ({ gridCells }: PropTypes) => {
-      
+
       const { gridCells: gcProp, allowableCellList, zoomLevel, plannedRouteList  } = useContext(MapContext).props
 
       // collate list of named polygons
@@ -27,10 +28,10 @@ export const HexGrid: React.FC<PropTypes> = ({ gridCells }: PropTypes) => {
 
       // Use direct property if available, otherwise, use context prop.
       const gc = gridCells || gcProp
-      
-      const setCellStyle = (cell: string, pc:Array<string>, ac: Array<string>): string => 
+
+      const setCellStyle = (cell: string, pc:Array<string>, ac: Array<string>): string =>
       `${pc && pc.includes(cell) ? 'planned' : ac && ac.includes(cell) ? 'allowable' : 'default'}-hex`
-      
+
       // Watch the 'allowableCellList' property for changes and update the state accordingly
       useEffect(() => {
         setAllowableCells(allowableCellList)
@@ -75,8 +76,6 @@ export const HexGrid: React.FC<PropTypes> = ({ gridCells }: PropTypes) => {
         })
       }
 
-      const uniqid: number = Math.floor(Math.random() * 1000); 
-
        return <>
         <LayerGroup key={'hex_polygons'} >{Object.keys(polygons).map(k => (
           <Polygon
@@ -85,7 +84,7 @@ export const HexGrid: React.FC<PropTypes> = ({ gridCells }: PropTypes) => {
             // TODO: There's a bad smell here. We're using the uniqid to
             // force the Leaflet polygon to redraw.  They were being
             // redrawn on change of `positions` attribute, but not classname
-            key = {'hex_poly_' + k + '_' + uniqid}
+            key = {'hex_poly_' + k + '_'}
             positions={polygons[k]}
             className={styles[setCellStyle(k, plannedRouteCells, allowableCells)]}
           />

--- a/packages/components/src/local/hex-grid/index.tsx
+++ b/packages/components/src/local/hex-grid/index.tsx
@@ -81,10 +81,7 @@ export const HexGrid: React.FC<PropTypes> = ({ gridCells }: PropTypes) => {
           <Polygon
             // we may end up with other elements per hex,
             // such as labels so include prefix in key
-            // TODO: There's a bad smell here. We're using the uniqid to
-            // force the Leaflet polygon to redraw.  They were being
-            // redrawn on change of `positions` attribute, but not classname
-            key = {'hex_poly_' + k + '_'}
+            key = {'hex_poly_' + k}
             positions={polygons[k]}
             className={styles[setCellStyle(k, plannedRouteCells, allowableCells)]}
           />


### PR DESCRIPTION
## 🧰 Issue
closes #403 


## 🚀 Overview: 
Leaflet elements not works as react component. As we know the leaflet can take only static html as item. So those elements updating with functions. By default updating function updates only on positions change.

## 🔗 Link to preview

## 🤔 Reason: 
I had created custom react-leaflet Polygon component witch one will extends "Path" class from "react-leaflet"  and added the equal code as in "react-leaflet" Polygon class and add the changes the update function to detect classname changes and update those. 

## 🔨Work carried out:

## 🖥️ Screenshot

## Confirmations

## 📝 Developer Notes:
I am not able to extend Polygon class from "react-leaflet" as it exported:
`export default withLeaflet<Props, Polygon>(Polygon)`
So I created the the custom component


