### PR TITLE
fix map bar

### DIFF
--- a/packages/components/src/local/map-bar/helpers/collate-perception-form-data.ts
+++ b/packages/components/src/local/map-bar/helpers/collate-perception-form-data.ts
@@ -10,6 +10,7 @@ const collatePerceptionFormData = (platforms: any, selectedAsset: SelectedAsset,
 ): PerceptionFormData => {
   const availableForceList: ColorOption[] = availableForces(forces, true)
   const platformTypes = platforms && platforms.map((p: any) => p.name)
+  platformTypes.push('Unknown')
   const formData: PerceptionFormData = {
     populate: {
       perceivedForce: availableForceList,

--- a/packages/components/src/local/map-bar/index.tsx
+++ b/packages/components/src/local/map-bar/index.tsx
@@ -51,13 +51,13 @@ export const MapBar: React.FC = () => {
     let output = null
     switch (form) {
       case 'PerceivedAs':
-        output = <PerceptionForm formData={collatePerceptionFormData(platforms, selectedAsset, forces)} postBack={postBack} />
+        output = <PerceptionForm key={selectedAsset.uniqid} formData={collatePerceptionFormData(platforms, selectedAsset, forces)} postBack={postBack} />
         break
       case 'Adjudication':
-        output = <AdjudicateTurnForm formHeader={currentAssetName} formData={collateAdjudicationFormData(platforms, selectedAsset, forces)} postBack={postBack} />
+        output = <AdjudicateTurnForm key={selectedAsset.uniqid} formHeader={currentAssetName} formData={collateAdjudicationFormData(platforms, selectedAsset, forces)} postBack={postBack} />
         break
       case 'Planning':
-        output = <PlanTurnForm formHeader={currentAssetName} formData={collatePlanFormData(platforms, selectedAsset)} postBack={postBack}/>
+        output = <PlanTurnForm key={selectedAsset.uniqid} formHeader={currentAssetName} formData={collatePlanFormData(platforms, selectedAsset)} postBack={postBack}/>
         break
       default:
         output = null


### PR DESCRIPTION
<!-- 
Please ensure that you complete the following mandatory sections:

- Issue*
- Overview
- Reason*
- Work carried out
- Confirmations

* Only mandatory if working from a issue
 -->

## 🧰 Issue
<!-- [The issue the work was done for as an issue reference (e.g. `closes #1`)] -->
Closes #418

## 🚀 Overview: 
<!-- [A summary of what you did in no more than one paragraph] -->

## 🔗 Link to preview
<!-- [If you're on a project which auto-deploys branches, link to the branches preview link here] -->

## 🤔 Reason: 
<!-- [Why did you do what you did? - This should be copied from the User Story part of the issue if it is available] -->
The map bar re rendering only if form type changing between `['PerceivedAs', 'Adjudication', 'Planning']`. So I was added the key prop to change it with `selectedAsset.uniqid`

## 🔨Work carried out:

<!-- [A list of work you have done, use [markdown checklist format](https://github.blog/2013-01-09-task-lists-in-gfm-issues-pulls-comments/), if you leave any boxes unchecked, be sure to leave this PR as a draft. If the issue has Acceptance Criteria, you should include those items to show that you have accomplished the goals of the issue ] -->

- [x] Tests pass

## 🖥️ Screenshot
<!-- [If the work is UI related then paste a screenshot of the update here. Where possible, please use an animated screenshot.] -->
![изображение](https://user-images.githubusercontent.com/20753599/82125777-593aef80-97b9-11ea-9287-7c13f4f4dd6d.png)


## Confirmations

- [ ] I have chosen reviewers for my PR.
- [ ] I have assigned myself to this PR.
- [ ] I have chosen an appropriate label for the PR.
- [ ] I have completed the mandatory sections of this document.
- [ ] I have deleted any unused sections.
- [ ] I confirm that I have checked for required README updates and acted accordingly.

## 📝 Developer Notes:
<!-- [Sometimes, extra notes are needed to add clarity to a PR, add them here] -->

