### PR TITLE
fix map bar index

### DIFF
--- a/packages/components/src/local/map-bar/styles.module.scss
+++ b/packages/components/src/local/map-bar/styles.module.scss
@@ -2,7 +2,7 @@
   position: absolute;
   left: -350px;
   top: 0;
-  z-index: 9999;
+  z-index: 1010;
   width: 350px;
   height: 100%;
   transition: left 0.5s ease-in-out;


### PR DESCRIPTION
<!-- 
Please ensure that you complete the following mandatory sections:

- Issue*
- Overview
- Reason*
- Work carried out
- Confirmations

* Only mandatory if working from a issue
 -->

## 🧰 Issue
<!-- [The issue the work was done for as an issue reference (e.g. `closes #1`)] -->
Closes #418

## 🚀 Overview: 
<!-- [A summary of what you did in no more than one paragraph] -->

## 🔗 Link to preview
<!-- [If you're on a project which auto-deploys branches, link to the branches preview link here] -->

## 🤔 Reason: 
<!-- [Why did you do what you did? - This should be copied from the User Story part of the issue if it is available] -->
Material ui z Index less than map bar zIndex

## 🔨Work carried out:

<!-- [A list of work you have done, use [markdown checklist format](https://github.blog/2013-01-09-task-lists-in-gfm-issues-pulls-comments/), if you leave any boxes unchecked, be sure to leave this PR as a draft. If the issue has Acceptance Criteria, you should include those items to show that you have accomplished the goals of the issue ] -->

- [x] Tests pass

## 🖥️ Screenshot
<!-- [If the work is UI related then paste a screenshot of the update here. Where possible, please use an animated screenshot.] -->

## Confirmations

- [ ] I have chosen reviewers for my PR.
- [ ] I have assigned myself to this PR.
- [ ] I have chosen an appropriate label for the PR.
- [ ] I have completed the mandatory sections of this document.
- [ ] I have deleted any unused sections.
- [ ] I confirm that I have checked for required README updates and acted accordingly.

## 📝 Developer Notes:
<!-- [Sometimes, extra notes are needed to add clarity to a PR, add them here] -->
It was not a good practice to add the big Z Indexes for boxes. Need to compare it with z-indexes which ones used for material ui. It will be good if all z indexes for project was fixed in some config file
