### PR TITLE
Hotfix - location of asset icons.

### DIFF
--- a/packages/components/src/local/asset-icon/styles.module.scss
+++ b/packages/components/src/local/asset-icon/styles.module.scss
@@ -1,5 +1,5 @@
 .asset-icon {
-  position: relative;
+  position: absolute;
   border-radius: 100%;
   background-repeat: no-repeat;
   background-position: 50%;


### PR DESCRIPTION
## 🧰 Issue
<!-- [The issue the work was done for as an issue reference (e.g. `closes #1`)] -->
Fixes #424 

## 🚀 Overview: 
<!-- [A summary of what you did in no more than one paragraph] -->

It appeared that there were two spatial projections in use.  Eventually I learned it was down to the use of `position:relative` forcing the browser to introduce vertical increments.

## 🔗 Link to preview
<!-- [If you're on a project which auto-deploys branches, link to the branches preview link here] -->
https://serge-review-bugfix-424-cqglek.herokuapp.com/storybook/?path=/story/local-mapping--with-assets

## 🔨Work carried out:

* [x] Correction of single CSS attribute.
- [x] Tests pass

## 🖥️ Screenshot
This is the fixed behaviour:
![screencast](https://i.gyazo.com/9b7c445c75ccf3b7032720751deed27a.gif)

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have assigned myself to this PR.
- [x] I have chosen an appropriate label for the PR.
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
- [x] I confirm that I have checked for required README updates and acted accordingly.
