### PR TITLE
Hotfix linter for scss

### DIFF
--- a/packages/components/src/local/helper-elements/dropzone/index.stories.tsx
+++ b/packages/components/src/local/helper-elements/dropzone/index.stories.tsx
@@ -29,7 +29,7 @@ export const Default: React.FC = () => (
     <Dropzone type='empty' active={'2'} item={{ uniqid: '4', name: 'g3' }}>Empty Type</Dropzone>
     <Dropzone type='group' active={'2'} item={{ uniqid: '5', name: 'g4' }}>Group Type</Dropzone>
     <Dropzone type='empty' active={'2'} item={{ uniqid: '5', name: 'g4' }}>Empty Type</Dropzone>
-    <Dropzone type='group_out' active={'2'} item={{ uniqid: '-1' }}>Title</Dropzone>
+    <Dropzone type='group-out' active={'2'} item={{ uniqid: '-1' }}>Title</Dropzone>
   </div>
 )
 

--- a/packages/components/src/local/helper-elements/dropzone/index.tsx
+++ b/packages/components/src/local/helper-elements/dropzone/index.tsx
@@ -31,7 +31,7 @@ export const Dropzone: React.FC<PropTypes> = ({ children, item, type = 'empty', 
   switch (type) {
     case 'group': typeGroup = true; activeDropzone = !!active; break
     case 'empty': typeEmpty = true; activeDropzone = showEmpty; break
-    case 'group_out': typeOut = true; activeDropzone = showEmpty; break
+    case 'group-out': typeOut = true; activeDropzone = showEmpty; break
   }
 
   const mouseMove = (e: MouseEvent): void => {

--- a/packages/components/src/local/helper-elements/dropzone/styles.module.scss
+++ b/packages/components/src/local/helper-elements/dropzone/styles.module.scss
@@ -18,7 +18,7 @@ $item-height: 44px;
   height: $item-height;
 }
 
-.main-group_out {
+.main-group-out {
   position: absolute;
   left: 0;
   width: 22px;
@@ -34,7 +34,7 @@ $item-height: 44px;
     height: calc(100% + #{$item-height});
   }
 }
-.group_out-active {
+.group-out-active {
   width: 22px;
 }
 
@@ -111,7 +111,7 @@ $item-height: 44px;
   }
 }
 
-.content-group_out {
+.content-group-out {
   white-space: nowrap;
   transform: rotateZ(90deg);
 }

--- a/packages/components/src/local/helper-elements/dropzone/types/props.d.ts
+++ b/packages/components/src/local/helper-elements/dropzone/types/props.d.ts
@@ -3,7 +3,7 @@ interface DropItem {
   [property: string]: any
 }
 
-export type DropType = 'empty' | 'group' | 'group_out'
+export type DropType = 'empty' | 'group' | 'group-out'
 
 export default interface PropTypes {
   item: DropItem

--- a/packages/components/src/local/helper-elements/groups/index.tsx
+++ b/packages/components/src/local/helper-elements/groups/index.tsx
@@ -84,7 +84,7 @@ export const Groups: React.FC<PropTypes> = (props) => {
         item={{ uniqid: -1 }}
         onEnd={onEnd}
         active={dragItem}
-        type='group_out'
+        type='group-out'
         onSet={(items: Array<DropItem>, type: NodeType): void => handleSet(items, type, []) }
       />}
     </div>

--- a/packages/components/src/local/helper-elements/groups/types/props.d.ts
+++ b/packages/components/src/local/helper-elements/groups/types/props.d.ts
@@ -5,7 +5,7 @@ export interface GroupItem {
   [property: string]: any
 }
 
-export type NodeType = 'empty' | 'group' | 'group_out'
+export type NodeType = 'empty' | 'group' | 'group-out'
 
 export default interface PropTypes {
   items?: Array<GroupItem>

--- a/packages/components/src/local/hex-grid/index.tsx
+++ b/packages/components/src/local/hex-grid/index.tsx
@@ -64,11 +64,13 @@ export const HexGrid: React.FC<{}> = () => {
    * get rendered in a suitable color
    */
   useEffect(() => {
-    // get the color for this asset
-    const current: Route = viewAsRouteStore.routes.find((route: Route) => route.uniqid === selectedAsset.uniqid)
-    if (current) {
-      setAssetColor(current.color)
-    //  setDarkAssetColor(colorShade(current.color, -50))
+    if(selectedAsset) {
+      // get the color for this asset
+      const current: Route = viewAsRouteStore.routes.find((route: Route) => route.uniqid === selectedAsset.uniqid)
+      if (current) {
+        setAssetColor(current.color)
+      //  setDarkAssetColor(colorShade(current.color, -50))
+      }
     }
   }, [selectedAsset])
 

--- a/packages/components/src/local/hex-grid/index.tsx
+++ b/packages/components/src/local/hex-grid/index.tsx
@@ -64,7 +64,7 @@ export const HexGrid: React.FC<{}> = () => {
    * get rendered in a suitable color
    */
   useEffect(() => {
-    if(selectedAsset) {
+    if (selectedAsset) {
       // get the color for this asset
       const current: Route = viewAsRouteStore.routes.find((route: Route) => route.uniqid === selectedAsset.uniqid)
       if (current) {

--- a/packages/components/src/local/world-state/index.tsx
+++ b/packages/components/src/local/world-state/index.tsx
@@ -177,7 +177,7 @@ export const WorldState: React.FC<PropTypes> = ({
               newRoutes = createNewGroup(newRoutes, items, depth, groupForce)
               setTmpRoutes(newRoutes as Array<Route>)
               break
-            case 'group_out':
+            case 'group-out':
               const perceivedForceName = getForceName(droppedItem, tmpRoutes)
               newRoutes = removeItem(tmpRoutes, [droppedItem.uniqid])
               newRoutes.push({

--- a/packages/components/src/local/world-state/index.tsx
+++ b/packages/components/src/local/world-state/index.tsx
@@ -27,7 +27,7 @@ export const WorldState: React.FC<PropTypes> = ({
    */
 
   useEffect(() => {
-    setTmpRoutes(store.routes.filter(r => r.underControl  === !showOtherPlatforms))
+    setTmpRoutes(store.routes.filter(r => r.underControl === !showOtherPlatforms))
   }, [store, phase, showOtherPlatforms])
 
   // an asset has been clicked on
@@ -171,13 +171,14 @@ export const WorldState: React.FC<PropTypes> = ({
           // TODO: remove setTmpRoutes and use api
           let newRoutes
           switch (type) {
-            case 'group':
+            case 'group': {
               const groupForce = getForceName(droppedInTo, tmpRoutes)
               newRoutes = removeItem(tmpRoutes, items.map(i => i.uniqid))
               newRoutes = createNewGroup(newRoutes, items, depth, groupForce)
               setTmpRoutes(newRoutes as Array<Route>)
               break
-            case 'group-out':
+            }
+            case 'group-out': {
               const perceivedForceName = getForceName(droppedItem, tmpRoutes)
               newRoutes = removeItem(tmpRoutes, [droppedItem.uniqid])
               newRoutes.push({
@@ -186,6 +187,7 @@ export const WorldState: React.FC<PropTypes> = ({
               })
               setTmpRoutes(newRoutes as Array<Route>)
               break
+            }
             default:
               newRoutes = removeItem(tmpRoutes, [droppedItem.uniqid])
               newRoutes = moveToGroup(newRoutes, droppedInTo, droppedItem)


### PR DESCRIPTION
Hotfix for failing linter:

![image](https://user-images.githubusercontent.com/1108513/90014713-7c354c80-dc9f-11ea-956e-9333176fa605.png)

Also fixes null pointer exception when clearing selected asset.
