### PR TITLE
Only allow top level elements to be selected

### DIFF
--- a/packages/components/src/local/world-state/index.tsx
+++ b/packages/components/src/local/world-state/index.tsx
@@ -64,10 +64,9 @@ export const WorldState: React.FC<PropTypes> = ({
   const playerInAdjudication: boolean = !isUmpire && phase === ADJUDICATION_PHASE
 
   const renderContent = (item: GroupItem, depth: Array<GroupItem> = []): JSX.Element => {
-
     // determine if this asset can be selected. We only allow assets at the top level
     // to be selected, since child elements are "managed" by the parent
-    const canBeSelected:boolean = depth && depth.length === 0
+    const canBeSelected: boolean = depth && depth.length === 0
 
     // const item = routeItem as PlannedRoute
     let forceName: string = item.perceivedForceName || ''

--- a/packages/components/src/local/world-state/index.tsx
+++ b/packages/components/src/local/world-state/index.tsx
@@ -64,6 +64,11 @@ export const WorldState: React.FC<PropTypes> = ({
   const playerInAdjudication: boolean = !isUmpire && phase === ADJUDICATION_PHASE
 
   const renderContent = (item: GroupItem, depth: Array<GroupItem> = []): JSX.Element => {
+
+    // determine if this asset can be selected. We only allow assets at the top level
+    // to be selected, since child elements are "managed" by the parent
+    const canBeSelected:boolean = depth && depth.length === 0
+
     // const item = routeItem as PlannedRoute
     let forceName: string = item.perceivedForceName || ''
     // if we don't know the force name, just use the one from the parent
@@ -80,7 +85,7 @@ export const WorldState: React.FC<PropTypes> = ({
     const checkStatus: boolean = numPlanned > 0
 
     return (
-      <div className={styles.item} onClick={(): any => clickEvent(`${item.uniqid}`)}>
+      <div className={styles.item} onClick={(): any => canBeSelected && clickEvent(`${item.uniqid}`)}>
         <div className={cx(icClassName, styles['item-icon'])}/>
         <div className={styles['item-content']}>
           <div>


### PR DESCRIPTION
<!-- 
Please ensure that you complete the following mandatory sections:

- Issue*
- Overview
- Reason*
- Work carried out
- Confirmations

* Only mandatory if working from a issue
 -->

## 🧰 Issue
<!-- [The issue the work was done for as an issue reference (e.g. `closes #1`)] -->
Fixes #513 

## 🚀 Overview: 
<!-- [A summary of what you did in no more than one paragraph] -->
An error was being thrown when a child platform was selected in WorldState.  This is because findAsset only searched the top tier of assets.  But actually, 

## 🔗 Link to preview
<!-- [If you're on a project which auto-deploys branches, link to the branches preview link here] -->
https://serge-review-bugfix-513-xkeurp.herokuapp.com/storybook/?path=/story/local-mapping--with-assets
## 🤔 Reason: 
<!-- [Why did you do what you did? - This should be copied from the User Story part of the issue if it is available] -->
Fix error being thrown at console.
## 🔨Work carried out:

<!-- [A list of work you have done, use [markdown checklist format](https://github.blog/2013-01-09-task-lists-in-gfm-issues-pulls-comments/), if you leave any boxes unchecked, be sure to leave this PR as a draft. If the issue has Acceptance Criteria, you should include those items to show that you have accomplished the goals of the issue ] -->

- [x] Tests pass

## 🖥️ Screenshot
<!-- [If the work is UI related then paste a screenshot of the update here. Where possible, please use an animated screenshot.] -->
![screencast](https://i.gyazo.com/0b39f0ef2dc0bda80501f28e524a6465.gif)

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have assigned myself to this PR.
- [x] I have chosen an appropriate label for the PR.
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
- [x] I confirm that I have checked for required README updates and acted accordingly.

## 📝 Developer Notes:
<!-- [Sometimes, extra notes are needed to add clarity to a PR, add them here] -->

