### PR TITLE
543 - display history in correct color

### DIFF
--- a/packages/helpers/is-perceived-by.ts
+++ b/packages/helpers/is-perceived-by.ts
@@ -35,8 +35,14 @@ const isPerceivedBy = (perceptions: any, playerForce: string,
       const upperForce = upperFirst(playerForce)
       const perception = perceptions[upperForce]
       if(perception) {
-        const force = forceColors.find((f:any) => f.force.toLowerCase() === playerForce.toLowerCase())
-        return (force && force.color) || undefined
+        if(perception.force) {
+          // find the force color for this force name
+          const force = forceColors.find((f:any) => f.force.toLowerCase() === perception.force.toLowerCase())
+          return (force && force.color) || undefinedColor  
+        } else {
+          // this force can perceive it, but doesn't know force. So, use undefined color
+          return undefinedColor
+        }
       } else {
         return undefined
       }

--- a/packages/helpers/tests/is-perceived.by.spec.ts
+++ b/packages/helpers/tests/is-perceived.by.spec.ts
@@ -1,0 +1,49 @@
+import isPerceivedBy from '../is-perceived-by'
+import forceColors from '../force-colors'
+
+/**
+ * the updated perceptions data model used an array
+ */
+const currentPerceptions = [{
+  by: 'Red',
+  force: 'Blue',
+  name: 'Frigate A Perceived Name'
+}, {
+  by: 'Green'
+}]
+
+/**
+ *  the original perceptions data model used a dictionary
+ */
+const legacyPerceptions = {
+  Red: {force: "Blue", type: ""},
+  Green: {}
+}
+
+import { forces } from '@serge/mocks'
+
+const forceColorList = forceColors(forces)
+
+const undefinedColor = '#fff'
+
+describe('isPercivedBy current', () => {
+  it('returns valid results for current schema ', () => {
+    // can't see it, so return undefined
+    expect(isPerceivedBy(currentPerceptions, 'Blue', forceColorList, undefinedColor)).toEqual(undefined)
+    // doesn't know force, so return undefined color
+    expect(isPerceivedBy(currentPerceptions, 'Green', forceColorList, undefinedColor)).toEqual(undefinedColor)
+    // has perceived color. use it
+    expect(isPerceivedBy(currentPerceptions, 'Red', forceColorList, undefinedColor)).toEqual('#00F')
+  })
+})
+
+describe('isPercivedBy legacy', () => {
+  it('returns valid results for legacy schema ', () => {
+    // can't see it, so return undefined
+    expect(isPerceivedBy(legacyPerceptions, 'Blue', forceColorList, undefinedColor)).toEqual(undefined)
+    // doesn't know force, so return undefined color
+    expect(isPerceivedBy(legacyPerceptions, 'Green', forceColorList, undefinedColor)).toEqual(undefinedColor)
+    // has perceived color. use it
+    expect(isPerceivedBy(legacyPerceptions, 'Red', forceColorList, undefinedColor)).toEqual('#00F')
+  })
+})


### PR DESCRIPTION
## 🧰 Issue
<!-- [The issue the work was done for as an issue reference (e.g. `closes #1`)] -->
Fixes #543 

## 🚀 Overview: 
<!-- [A summary of what you did in no more than one paragraph] -->

Correctly get data from legacy Perceptions data object.

## 🔗 Link to preview
<!-- [If you're on a project which auto-deploys branches, link to the branches preview link here] -->

## 🤔 Reason: 
<!-- [Why did you do what you did? - This should be copied from the User Story part of the issue if it is available] -->

## 🔨Work carried out:

<!-- [A list of work you have done, use [markdown checklist format](https://github.blog/2013-01-09-task-lists-in-gfm-issues-pulls-comments/), if you leave any boxes unchecked, be sure to leave this PR as a draft. If the issue has Acceptance Criteria, you should include those items to show that you have accomplished the goals of the issue ] -->
- [x] Write unit tests to cover isPerceivedBy
- [x] Update code to make tests pass
- [x] Tests pass

## 🖥️ Screenshot
<!-- [If the work is UI related then paste a screenshot of the update here. Where possible, please use an animated screenshot.] -->

### Before
![image](https://user-images.githubusercontent.com/1108513/96463108-43c16a00-121e-11eb-9ce7-1785eb9a256d.png)


### After
![image](https://user-images.githubusercontent.com/1108513/96463060-37d5a800-121e-11eb-8dcc-93c3457b4371.png)


## Confirmations

- [ ] I have chosen reviewers for my PR.
- [ ] I have assigned myself to this PR.
- [ ] I have chosen an appropriate label for the PR.
- [ ] I have completed the mandatory sections of this document.
- [ ] I have deleted any unused sections.
- [ ] I confirm that I have checked for required README updates and acted accordingly.

## 📝 Developer Notes:
<!-- [Sometimes, extra notes are needed to add clarity to a PR, add them here] -->

