### PR TITLE
Update README.md

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -162,4 +162,4 @@ For an example of documenting a third-party component, please take a look at the
 
 ## Contributing
 
-If you want to contribute components to the library, please review our [Development Standards Guidelines](../../development-standards.md) first.
+If you want to contribute components to the library, please review our [Development Standards Guidelines](https://github.com/serge-web/serge/blob/develop/docs/index.md) first.


### PR DESCRIPTION
## 🚀 Overview: 
I was looking through the readme and noticed that the bottom link to the development standards docs linked to the old markdown file instead of the more recent `docs` folder. This fixes that.

## 🤔 Reason: 

![image](https://user-images.githubusercontent.com/151028/96711478-88bbdc80-1395-11eb-9693-3beb95a32a98.png)

## 🔨Work carried out:

- [x] Fixed link

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have assigned myself to this PR.
- [x] I have chosen an appropriate label for the PR.
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
- [x] I confirm that I have checked for required README updates and acted accordingly.
