### PR TITLE
Feature/78 Refactor template references

### DIFF
--- a/packages/client/src/ActionsAndReducers/playerUi/playerUi_Reducer.js
+++ b/packages/client/src/ActionsAndReducers/playerUi/playerUi_Reducer.js
@@ -85,7 +85,9 @@ export const playerUiReducer = (state = initialState, action) => {
       if (chosenTemplates.length === 0) {
         templates = newState.allTemplates.filter((template) => template.title === 'Chat')
       } else {
-        templates = chosenTemplates.map((template) => template.value)
+        templates = chosenTemplates.map(({ value }) => {
+          return typeof value === 'string' ? newState.allTemplates.find(item => item._id === value) : value
+        })
       }
     }
 

--- a/packages/client/src/Components/Layout/ChannelsTable.jsx
+++ b/packages/client/src/Components/Layout/ChannelsTable.jsx
@@ -160,7 +160,7 @@ class ChannelsTable extends Component {
 
     let templateIds = this.state.selectedTemplates.map((template) => ({_id: template.value}));
     let templates = _.intersectionBy(this.props.messageTypes.messages, templateIds, (item) => item._id);
-    templates = templates.map((template) => ({label: template.title, value: template}));
+    templates = templates.map(({ _id, title }) => ({ label: title, value: _id, }));
     const { forces } = this.props.wargame.data.forces
     const addedForce = forces.find((f) => f.uniqid === this.state.selectedForce.value)
     const {

--- a/packages/client/src/Components/Layout/EditSubscriptionRow.jsx
+++ b/packages/client/src/Components/Layout/EditSubscriptionRow.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-
 import Select from "react-select";
 import {
   faCheck,
@@ -7,7 +6,6 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import _ from "lodash";
-
 import "@serge/themes/App.scss";
 
 class EditSubscriptionRow extends Component {
@@ -85,7 +83,7 @@ class EditSubscriptionRow extends Component {
       return {_id: template.value._id};
     });
     let templates = _.intersectionBy(this.props.messageTypes.messages, templateIds, (item) => item._id);
-        templates = templates.map((template) => ({label: template.title, value: template}));
+        templates = templates.map(({ _id, title }) => ({ label: title, value: _id }));
 
     const {
       value: forceUniqid,

--- a/packages/client/src/Components/NewMessage.jsx
+++ b/packages/client/src/Components/NewMessage.jsx
@@ -1,84 +1,63 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import Collapsible from "react-collapsible";
-import MessageCreator from "../Components/MessageCreator.jsx";
-import DropdownInput from "../Components/Inputs/DropdownInput";
+import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import Collapsible from 'react-collapsible'
+import MessageCreator from '../Components/MessageCreator.jsx'
+import DropdownInput from '../Components/Inputs/DropdownInput'
+import '@serge/themes/App.scss'
 
-import "@serge/themes/App.scss";
+const NewMessage = props => {
+  const { templates, curChannel, privateMessage, orderableChannel } = props
+  const [selectedSchema, setSelectedSchema] = useState(null)
 
-class NewMessage extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      selectedSchema: null,
-    };
+  const mapTemplateToDropdown = (item) => ({
+    value: JSON.stringify(item.details),
+    option: item.title
+  })
+  const setTemplate = val => {
+    setSelectedSchema(JSON.parse(val))
   }
 
-  componentDidMount() {
-    if (this.props.templates.length === 1) {
-      this.setState({
-        selectedSchema: this.props.templates[0].details,
-      })
-    }
-  }
+  const allTemplates = templates.map(mapTemplateToDropdown)
+  const classes = `new-message-creator wrap ${orderableChannel ? 'new-message-orderable' : ''}`
 
-  componentWillReceiveProps(nextProps, nextContext) {
-    if (this.props.curChannel !== nextProps.curChannel) {
-      this.setState({
-        selectedSchema: null,
-      })
-    }
-    if (nextProps.templates.length === 1) {
-      this.setState({
-        selectedSchema: nextProps.templates[0].details,
-      })
-    }
-  }
+  useEffect(() => {
+    setSelectedSchema(null)
+  }, [curChannel])
 
-  setTemplate = (val) => {
-    this.setState({
-      selectedSchema: JSON.parse(val),
-    });
-  };
+  useEffect(() => {
+    setSelectedSchema(templates[0].details)
+  }, [templates])
 
-
-  render() {
-    const templates = this.props.templates.map((item) => ({value: JSON.stringify(item.details), option: item.title }));
-    let classes = "new-message-creator wrap";
-    if (this.props.orderableChannel) classes += " new-message-orderable";
-
-    return (
-      <div className={classes}>
-        <Collapsible
-          trigger={"New Message"}
-          transitionTime={200}
-          easing={'ease-in-out'}
-        >
-          {templates.length > 1 &&
+  return (
+    <div className={classes}>
+      <Collapsible
+        trigger={'New Message'}
+        transitionTime={200}
+        easing={'ease-in-out'}
+      >
+        {
+          allTemplates.length > 1 && (
             <DropdownInput
-              updateStore={this.setTemplate}
-              // data={this.state.dropdownValue}
-              selectOptions={templates}
+              updateStore={setTemplate}
+              selectOptions={allTemplates}
               placeholder="Select message"
               className="message-input"
             />
-          }
-          <MessageCreator
-            schema={this.state.selectedSchema}
-            curChannel={this.props.curChannel}
-            privateMessage={this.props.privateMessage}
-          />
-        </Collapsible>
-      </div>
-    );
-  }
+          )
+        }
+        <MessageCreator
+          schema={selectedSchema}
+          curChannel={curChannel}
+          privateMessage={privateMessage}
+        />
+      </Collapsible>
+    </div>
+  )
 }
+export default NewMessage
 
 NewMessage.propTypes = {
   templates: PropTypes.array.isRequired,
   curChannel: PropTypes.string.isRequired,
-  privateMessage: PropTypes.bool.isRequired,
-};
-
-export default NewMessage;
+  privateMessage: PropTypes.bool.isRequired
+}

--- a/packages/client/src/api/messageTypes_api.js
+++ b/packages/client/src/api/messageTypes_api.js
@@ -136,7 +136,7 @@ export const postNewMessage = (schema) => {
     (async () => {
       const allMessages = await getAllMessagesFromDb()
 
-      const matchedName = allMessages.find((messageType) => messageType.title.toLowerCase() === schema.title.toLowerCase())
+      const matchedName = allMessages.find((messageType) => messageType.title && schema.title && messageType.title.toLowerCase() === schema.title.toLowerCase())
 
       if (matchedName) {
         reject('Message title already used')

--- a/packages/themes/_playerUi.scss
+++ b/packages/themes/_playerUi.scss
@@ -596,11 +596,15 @@
     margin-bottom: 18px;
   }
 
+  select.message-input:first-child {
+    margin-top: 18px;
+  }
+
   .btn {
     float: right;
   }
 
-  h3 > span {
+  h3 {
     display: none;
   }
 


### PR DESCRIPTION
<!-- 
Please ensure that you complete the following mandatory sections:

- Issue*
- Overview
- Reason*
- Work carried out
- Confirmations

* Only mandatory if working from a issue
 -->

## 🧰 Issue
Closes #78 


## 🚀 Overview: 
The whole template object is currently stored in the database when the user creates/updates a channel.
The new implementation, stores only the template `_id` so that the player interface will be able to refer to the correct template with its latest structures.
This is using transitional approach where it can still read a channel that still uses a template object value on its structure.

## 🔗 Link to preview
<!-- [If you're on a project which auto-deploys branches, link to the branches preview link here] -->

## 🤔 Reason: 
We currently store the form templates in the channel descriptions.
But, changes to the template aren't reflected in the game.

## 🔨Work carried out:

- [x] Refactor channel table
- [x] Refactor edit subscription row
- [x] Refactor player ui reducer
- [x] Refactor new message component
- [x] Tests pass

## Confirmations

- [x] I have chosen reviewers for my PR.
- [x] I have assigned myself to this PR.
- [x] I have chosen an appropriate label for the PR.
- [x] I have completed the mandatory sections of this document.
- [x] I have deleted any unused sections.
- [x] I confirm that I have checked for required README updates and acted accordingly.
