### PR TITLE
Give databases a file suffix

### DIFF
--- a/packages/client/src/api/wargames_api.js
+++ b/packages/client/src/api/wargames_api.js
@@ -29,6 +29,10 @@ import {
 
 const wargameDbStore = []
 
+// give database documents a suffix, so they're easier to open
+// in database utility tools
+const dbSuffix = '.sqlite'
+
 const listenNewMessage = ({ db, name, dispatch }) => {
   db.changes({ since: 'now', live: true, timeout: false, heartbeat: false, include_docs: true })
     .on('change', function (changes) {
@@ -134,7 +138,7 @@ export const createWargame = (dispatch) => {
   const name = `wargame-${uniqId}`
 
   return new Promise((resolve, reject) => {
-    const db = new PouchDB(databasePath + name)
+    const db = new PouchDB(databasePath + name + dbSuffix)
 
     db.setMaxListeners(15)
 
@@ -631,7 +635,7 @@ export const cleanWargame = (dbPath) => {
 
     db.get(dbDefaultSettings._id)
       .then((res) => {
-        newDb = new PouchDB(databasePath + newDbName)
+        newDb = new PouchDB(databasePath + newDbName + dbSuffix)
         return res
       })
       .then((res) => {
@@ -669,7 +673,7 @@ export const duplicateWargame = (dbPath) => {
 
   return new Promise((resolve, reject) => {
     var newDbName = `wargame-${uniqId}`
-    var newDb = new PouchDB(databasePath + newDbName)
+    var newDb = new PouchDB(databasePath + newDbName + dbSuffix)
 
     return dbInStore.db.replicate.to(newDb)
       .then(() => {


### PR DESCRIPTION
Provide `.sqlite` file suffix, so we can open them more easily with database tools
