### PR TITLE
589 Hotfix - saving changed channel name broken

### DIFF
--- a/packages/client/src/Views/GameSetupNew.jsx
+++ b/packages/client/src/Views/GameSetupNew.jsx
@@ -128,18 +128,19 @@ const AdminGameSetup = () => {
 
   const handleSaveChannel = channel => {
     const channelName = channel.name
-    const selectedChannel = channels.selectedChannel.name
-    const newChannelData = channels.channels.find((c) => c.name === selectedChannel)
+    const selectedChannelName = channels.selectedChannel.name
+    const selectedChannelId = channels.selectedChannel.uniqid
+    const newChannelData = channels.channels.find((c) => c.uniqid === selectedChannelId)
 
     if (typeof channelName === 'string' && channelName.length > 0) {
       if (!isUniqueChannelName(channel)) return
 
       dispatch(setTabSaved())
-      dispatch(saveChannel(currentWargame, channelName, newChannelData, selectedChannel))
+      dispatch(saveChannel(currentWargame, channelName, newChannelData, selectedChannelName))
     }
 
     if (channelName === null) {
-      dispatch(saveChannel(currentWargame, selectedChannel, newChannelData, selectedChannel))
+      dispatch(saveChannel(currentWargame, selectedChannelName, newChannelData, selectedChannelName))
     } else if (channelName.length === 0) {
       window.alert('no channel name')
     }


### PR DESCRIPTION
Fixes #589 

The issue arose when we were changing the channel name.  With a new channel name, it was not possible to find the channel using name - since that had changed. 

Switched to using the uniqid for the channel.
