### PR TITLE
Don't increment turn counter. This allows us to clear all planned routes

### DIFF
--- a/packages/components/src/local/mapping/index.tsx
+++ b/packages/components/src/local/mapping/index.tsx
@@ -366,7 +366,7 @@ export const Mapping: React.FC<PropTypes> = ({
   const clearFromTurn = (turn: number): void => {
     const current: Route | undefined = routeStore.selected
     if (current) {
-      const newStore = routeClearFromStep(routeStore, current.uniqid, turn + 1)
+      const newStore = routeClearFromStep(routeStore, current.uniqid, turn)
       setRouteStore(newStore)
       // now move the planning marker back to the last valid location
       const newCurrent: Route | undefined = newStore.selected


### PR DESCRIPTION
Fixes #645 