### PR TITLE
Hotfix/world state view of unknown platform

### DIFF
--- a/packages/components/src/local/form-elements/title-with-icon/README.md
+++ b/packages/components/src/local/form-elements/title-with-icon/README.md
@@ -1,4 +1,4 @@
-# Planned Route documentation
+# Title with icon documentation
 
 This is an example readme file for the 'TitleWithIcon' component.
 

--- a/packages/components/src/local/world-state/index.tsx
+++ b/packages/components/src/local/world-state/index.tsx
@@ -108,9 +108,9 @@ export const WorldState: React.FC<PropTypes> = ({
 
     let isDestroyed: boolean | undefined = false
     // If we know the platform type, we can determine if the platform is destroyed
-    if(item.platformType !== 'unknown') {
+    if (item.platformType !== 'unknown') {
       const platformType: PlatformTypeData | undefined = platforms && findPlatformTypeFor(platforms, item.platformType)
-      isDestroyed = platformType && item.condition === platformType.conditions[platformType.conditions.length - 1]  
+      isDestroyed = platformType && item.condition === platformType.conditions[platformType.conditions.length - 1]
     }
 
     const laydownMessage: string = panel === WorldStatePanels.Control && canSubmitOrders && item.laydownPhase !== LaydownPhases.NotInLaydown ? ' ' + item.laydownPhase : ''

--- a/packages/components/src/local/world-state/index.tsx
+++ b/packages/components/src/local/world-state/index.tsx
@@ -106,9 +106,12 @@ export const WorldState: React.FC<PropTypes> = ({
       ? `${numPlanned} turns planned` : ''
     const inAdjudication: boolean = phase === ADJUDICATION_PHASE && isUmpire
 
-    // sort out if this asset is destroyed
-    const platformType: PlatformTypeData | undefined = platforms && findPlatformTypeFor(platforms, item.platformType)
-    const isDestroyed = platformType && item.condition === platformType.conditions[platformType.conditions.length - 1]
+    let isDestroyed: boolean | undefined = false
+    // If we know the platform type, we can determine if the platform is destroyed
+    if(item.platformType !== 'unknown') {
+      const platformType: PlatformTypeData | undefined = platforms && findPlatformTypeFor(platforms, item.platformType)
+      isDestroyed = platformType && item.condition === platformType.conditions[platformType.conditions.length - 1]  
+    }
 
     const laydownMessage: string = panel === WorldStatePanels.Control && canSubmitOrders && item.laydownPhase !== LaydownPhases.NotInLaydown ? ' ' + item.laydownPhase : ''
     const checkStatus: boolean = item.laydownPhase === LaydownPhases.NotInLaydown


### PR DESCRIPTION
Hotfix - we were getting crash when viewing `visibility` for unknown platform type