### PR TITLE
include key in RFI messages

### DIFF
--- a/packages/components/src/local/organisms/channel-messages-list/index.tsx
+++ b/packages/components/src/local/organisms/channel-messages-list/index.tsx
@@ -37,6 +37,7 @@ export const ChannelMessagesList: React.FC<PropTypes> = ({ messages, playerForce
               return (
                 <Box mb={2} mr={2} key={key}>
                   <ChannelRFIMessage
+                    key={msg._id}
                     borderColor={msg.details.from.forceColor}
                     message={props}
                     onRead={onRead}


### PR DESCRIPTION
Fixes #659 

Provide the `key` field for the RFI message component.