### PR TITLE
795 invalid time step

### DIFF
--- a/packages/components/src/local/mapping/index.tsx
+++ b/packages/components/src/local/mapping/index.tsx
@@ -461,6 +461,8 @@ export const Mapping: React.FC<PropTypes> = ({
           // special case. check turn time is non-zero
           if (gameTurnTime === 0) {
             console.error('Cannot plan route with zero game turn time')
+            window.alert('Cannot plan route with zero game turn time')
+            // TODO: also display notification in UI
           }
           const speedKts = plannedTurn.speedVal
           const stepSizeHrs = gameTurnTime / 1000 / 60 / 60

--- a/packages/components/src/local/mapping/index.tsx
+++ b/packages/components/src/local/mapping/index.tsx
@@ -458,6 +458,10 @@ export const Mapping: React.FC<PropTypes> = ({
         // special handling, a mobile status may not have a speedVal,
         // which represents unlimited travel
         if (plannedTurn.speedVal) {
+          // special case. check turn time is non-zero
+          if (gameTurnTime === 0) {
+            console.error('Cannot plan route with zero game turn time')
+          }
           const speedKts = plannedTurn.speedVal
           const stepSizeHrs = gameTurnTime / 1000 / 60 / 60
           const distancePerTurn = stepSizeHrs * speedKts


### PR DESCRIPTION
Supports #795 

Note: this just pops up a warning if a `zero` value is encountered for `gameTurnTime`.