### PR TITLE
Display the insights panel first, if there is going to be one.

### DIFF
--- a/packages/client/src/Views/AdminAndInsightsTabsContainer/helpers/addTabs.ts
+++ b/packages/client/src/Views/AdminAndInsightsTabsContainer/helpers/addTabs.ts
@@ -2,15 +2,6 @@ import FlexLayout, { Model } from 'flexlayout-react'
 import { PlayerUi } from '@serge/custom-types'
 
 export default (state: PlayerUi, model: Model, gameAdmin: string, gameAdminTitle: string, insights: string): void => {
-  model.doAction(
-    FlexLayout.Actions.addNode({
-      type: 'tab',
-      component: gameAdmin,
-      name: gameAdminTitle,
-      id: gameAdmin
-    }, '#2', FlexLayout.DockLocation.CENTER, -1)
-  )
-
   if (state.isInsightViewer) {
     model.doAction(
       FlexLayout.Actions.addNode({
@@ -21,4 +12,14 @@ export default (state: PlayerUi, model: Model, gameAdmin: string, gameAdminTitle
       }, '#2', FlexLayout.DockLocation.CENTER, -1)
     )
   }
+
+  model.doAction(
+    FlexLayout.Actions.addNode({
+      type: 'tab',
+      component: gameAdmin,
+      name: gameAdminTitle,
+      id: gameAdmin
+    }, '#2', FlexLayout.DockLocation.CENTER, -1)
+  )
+
 }


### PR DESCRIPTION
By default, the Game Control doesn't see the Game Admin channel, because it's obscured by the Insights channel.

Insert the Insights channel first (if necessary) which will leave Game Admin at the top of the stack.