### PR TITLE
Hotfix reduce column headers

### DIFF
--- a/packages/client/src/ActionsAndReducers/ExportItems/ExportItems_ActionsCreators.ts
+++ b/packages/client/src/ActionsAndReducers/ExportItems/ExportItems_ActionsCreators.ts
@@ -52,7 +52,6 @@ export const createMessageExportItem = ({ currentWargame, exportMessagelist = []
 
 const keysSimplyfy = (row: FlatMessage): FlatMessage => {
   const newRow: FlatMessage = {}
-
   for (const key of Object.keys(row)) {
     const subkeys: string[] = key.split('.')
     let mainKey: string = subkeys[subkeys.length - 1]
@@ -60,15 +59,17 @@ const keysSimplyfy = (row: FlatMessage): FlatMessage => {
     const newKey = keysSimplyfyGetNewKey(subkeys, mainKey)
     newRow[newKey.join(' ')] = row[key]
   }
-
   return newRow
 }
 
 const keysSimplyfyGetNewKey = (subkeys: string[], mainKey: string): string[] => {
   const newKey = []
-  for (var i = 0; i < subkeys.length; i++) {
+  for (var i = 1; i < subkeys.length; i++) {
     if (subkeys[i].replace(/\s/g,"") !== "") {
-      newKey.push(`${subkeys[i - 1] || EXPORT_ITEM_MESSAGES}_${subkeys[i]}`)
+      // note: this used to be the format string, but the keys were being duplicated
+      // we also dropped the leading EXPORT_ITEM_MESSAGES key
+      // newKey.push(`${subkeys[i - 1] || EXPORT_ITEM_MESSAGES}_${subkeys[i]}`)
+      newKey.push(`${subkeys[i - 1]}`)
     }
   }
   if (mainKey) {

--- a/packages/client/src/ActionsAndReducers/ExportItems/ExportItems_ActionsCreators.ts
+++ b/packages/client/src/ActionsAndReducers/ExportItems/ExportItems_ActionsCreators.ts
@@ -50,18 +50,18 @@ export const createMessageExportItem = ({ currentWargame, exportMessagelist = []
   return createExportItem({ type: EXPORT_ITEM_MESSAGES, title, wargame: currentWargame, data })
 }
 
-const keysSimplyfy = (row: FlatMessage): FlatMessage => {
+const keysSimplify = (row: FlatMessage): FlatMessage => {
   const newRow: FlatMessage = {}
   for (const key of Object.keys(row)) {
     const subkeys: string[] = key.split('.')
     // if (typeof mainKey === undefined) mainKey = ''
-    const newKey = keysSimplyfyGetNewKey(subkeys)
+    const newKey = keysSimplifyGetNewKey(subkeys)
     newRow[newKey.join(' ')] = row[key]
   }
   return newRow
 }
 
-const keysSimplyfyGetNewKey = (subkeys: string[]): string[] => {
+const keysSimplifyGetNewKey = (subkeys: string[]): string[] => {
   const newKey = []
   for (var i = 0; i < subkeys.length; i++) {
     if (subkeys[i].replace(/\s/g,"") !== "") {
@@ -117,7 +117,7 @@ const exportDataGroupedGetRowsAndFields = (messages: Message[], message: Message
         msg.details.channel = channelTitles[msg.details.channel]
       }
     }
-    const flatMsg: FlatMessage = keysSimplyfy(flatten<Message, FlatMessage>(msg))
+    const flatMsg: FlatMessage = keysSimplify(flatten<Message, FlatMessage>(msg))
     const objectKeys = Object.keys(flatMsg)
     for (const key of objectKeys) {
       // check if fields/titles have no current key then add

--- a/packages/client/src/ActionsAndReducers/ExportItems/ExportItems_ActionsCreators.ts
+++ b/packages/client/src/ActionsAndReducers/ExportItems/ExportItems_ActionsCreators.ts
@@ -54,26 +54,22 @@ const keysSimplyfy = (row: FlatMessage): FlatMessage => {
   const newRow: FlatMessage = {}
   for (const key of Object.keys(row)) {
     const subkeys: string[] = key.split('.')
-    let mainKey: string = subkeys[subkeys.length - 1]
     // if (typeof mainKey === undefined) mainKey = ''
-    const newKey = keysSimplyfyGetNewKey(subkeys, mainKey)
+    const newKey = keysSimplyfyGetNewKey(subkeys)
     newRow[newKey.join(' ')] = row[key]
   }
   return newRow
 }
 
-const keysSimplyfyGetNewKey = (subkeys: string[], mainKey: string): string[] => {
+const keysSimplyfyGetNewKey = (subkeys: string[]): string[] => {
   const newKey = []
-  for (var i = 1; i < subkeys.length; i++) {
+  for (var i = 0; i < subkeys.length; i++) {
     if (subkeys[i].replace(/\s/g,"") !== "") {
       // note: this used to be the format string, but the keys were being duplicated
       // we also dropped the leading EXPORT_ITEM_MESSAGES key
       // newKey.push(`${subkeys[i - 1] || EXPORT_ITEM_MESSAGES}_${subkeys[i]}`)
-      newKey.push(`${subkeys[i - 1]}`)
+      newKey.push(`${subkeys[i]}`)
     }
-  }
-  if (mainKey) {
-    newKey.push(mainKey)
   }
   return newKey
 }

--- a/packages/client/src/Components/ExcelExport.jsx
+++ b/packages/client/src/Components/ExcelExport.jsx
@@ -37,14 +37,6 @@ const ExcelExport = ({ exp, index }) => {
       <a
         href={hreflink}
         className='link link--secondary'
-        onClick={e => generateFile('xls')}
-        id={ids.xls}
-      >
-        <FontAwesomeIcon icon={faFileDownload}/>Download .xls
-      </a>
-      <a
-        href={hreflink}
-        className='link link--secondary'
         onClick={e => generateFile('xlsx')}
         id={ids.xlsx}
       >


### PR DESCRIPTION
The headers on the XLS export are quite cumbersome, involving field name duplication, and an unnecessary first field name.

This PR simplifies the export, changing:
`MESSAGES_DETAILS DETAILS_COLLABORATION COLLABORATION_STATUS STATUS`
to:
`DETAILS COLLABORATION STATUS`

It also drops support for exporting in `.XLS` format, since for some large wargames Excel warned that some data may be missing.  Now we just support exporting in `.XLSX` format.