### PR TITLE
Make tab titles easier to read

### DIFF
--- a/packages/themes/dependencies/flexlayout-react.scss
+++ b/packages/themes/dependencies/flexlayout-react.scss
@@ -122,14 +122,14 @@
   float: left;
   vertical-align: top;
   box-sizing: border-box;
-  font-size: 12px;
-  font-weight: bold;
+  font-size: 13px;
   text-align: center;
-  color: $link-color;
+  color: #4bf;
   @include typo-secondary;
 }
 
 .flexlayout__tab_button--selected {
+  font-weight: bold;
   color: #ffffff;
   box-shadow: 0 -2px 4px 0 rgba(0, 0, 0, 0.4);
   border-style: solid;


### PR DESCRIPTION
Fixes #1087 

Old style:
![image](https://user-images.githubusercontent.com/1108513/132253651-667976a8-a20f-414d-9a27-e95f09a43b04.png)

New style: 
![image](https://user-images.githubusercontent.com/1108513/132253664-6b8af131-d792-4b2b-b90d-4abb4e914aa3.png)
