### PR TITLE
See if removing StoryBook allows build to complete

### DIFF
--- a/packages/components/.storybook/main.js
+++ b/packages/components/.storybook/main.js
@@ -2,8 +2,8 @@ const path = require('path')
 
 module.exports = {
     stories: [
-      '../src/**/*.stories.mdx',
-      '../src/**/*.stories.@(tsx)'
+      '../src/**/*.stories-inc.mdx',
+      '../src/**/*.stories-inc.@(tsx)'
     ],
     addons: [
         '@storybook/addon-links',


### PR DESCRIPTION
Put tighter constraint on Storybook naming, so no story tests are built.