### PR TITLE
Refactor json editor

### DIFF
--- a/packages/components/src/local/coa-status-board/helpers/gen-data.tsx
+++ b/packages/components/src/local/coa-status-board/helpers/gen-data.tsx
@@ -94,7 +94,7 @@ export const genData = (
       selector: (row: Row): React.ReactElement => (<><FontAwesomeIcon color={row.isReaded ? '#838585' : '#69c'} icon={row.isReaded ? faEnvelopeOpen : faEnvelope} />&nbsp;{row.id}</>),
       sortable: true,
       sortFunction: (rowA: Row, rowB: Row): number => sortCol(rowA.id, rowB.id),
-      center: true,
+      center: true
     },
     {
       name: 'From',

--- a/packages/components/src/local/molecules/channel-coa-message-detail/__snapshots__/index.spec.tsx.snap
+++ b/packages/components/src/local/molecules/channel-coa-message-detail/__snapshots__/index.spec.tsx.snap
@@ -8,9 +8,19 @@ exports[`ChannelMessageDetail: renders correctly 1`] = `
   <div
     className="actions"
   />
-  <div
-    className="edt-disable"
-  />
+  <span
+    style={
+      Object {
+        "background": "#ff0",
+        "color": "#f00",
+        "fontSize": "16px",
+        "padding": "20px",
+      }
+    }
+  >
+    Schema not found for 
+    CustomMessage
+  </span>
   <div
     className="actions"
   />

--- a/packages/components/src/local/molecules/channel-coa-message-detail/__snapshots__/index.spec.tsx.snap
+++ b/packages/components/src/local/molecules/channel-coa-message-detail/__snapshots__/index.spec.tsx.snap
@@ -24,6 +24,5 @@ exports[`ChannelMessageDetail: renders correctly 1`] = `
   <div
     className="actions"
   />
-          
 </div>
 `;

--- a/packages/components/src/local/molecules/channel-coa-message-detail/index.tsx
+++ b/packages/components/src/local/molecules/channel-coa-message-detail/index.tsx
@@ -127,7 +127,7 @@ export const ChannelCoaMessageDetail: React.FC<Props> = ({ templates, message, o
     expiredStorage.setItem(dialogOpenStatusKey, JSON.stringify(currentModalStatus))
   }
 
-  const getJsonEditorValue = (val: { [property: string]: any }): void => {
+  const storeNewValue = (val: { [property: string]: any }): void => {
     setNewMsg(val)
   }
 
@@ -378,7 +378,7 @@ export const ChannelCoaMessageDetail: React.FC<Props> = ({ templates, message, o
             messageContent={message.message}
             template={message.messageType}
             messageId={`${message._id}_${message.message.Reference}`}
-            getJsonEditorValue={getJsonEditorValue}
+            onChange={storeNewValue}
             disabled={!editDoc}
             gameDate={gameDate}
           />
@@ -429,7 +429,7 @@ export const ChannelCoaMessageDetail: React.FC<Props> = ({ templates, message, o
             messageContent={message.message}
             template={message.messageType}
             messageId={`${message._id}_${message.message.Reference}`}
-            getJsonEditorValue={getJsonEditorValue}
+            onChange={storeNewValue}
             disabled={true}
             gameDate={gameDate}
           />

--- a/packages/components/src/local/molecules/channel-coa-message-detail/index.tsx
+++ b/packages/components/src/local/molecules/channel-coa-message-detail/index.tsx
@@ -378,7 +378,7 @@ export const ChannelCoaMessageDetail: React.FC<Props> = ({ templates, message, o
             messageContent={message.message}
             template={message.messageType}
             messageId={`${message._id}_${message.message.Reference}`}
-            onChange={storeNewValue}
+            storeNewValue={storeNewValue}
             disabled={!editDoc}
             gameDate={gameDate}
           />
@@ -391,7 +391,7 @@ export const ChannelCoaMessageDetail: React.FC<Props> = ({ templates, message, o
               editDoc &&
               <Button customVariant="form-action" size="small" type="button" onClick={handleEditingSubmit}>Submit</Button>
             }
-          </div>        </>
+          </div></>
       ) : (
         <>
           <div className={styles.actions}>

--- a/packages/components/src/local/molecules/channel-coa-message-detail/index.tsx
+++ b/packages/components/src/local/molecules/channel-coa-message-detail/index.tsx
@@ -375,7 +375,9 @@ export const ChannelCoaMessageDetail: React.FC<Props> = ({ templates, message, o
           }
           <JsonEditor
             messageTemplates={templates}
-            message={message}
+            messageContent={message.message}
+            template={message.messageType}
+            messageId={`${message._id}_${message.message.Reference}`}
             getJsonEditorValue={getJsonEditorValue}
             disabled={!editDoc}
             gameDate={gameDate}
@@ -424,7 +426,9 @@ export const ChannelCoaMessageDetail: React.FC<Props> = ({ templates, message, o
           }
           <JsonEditor
             messageTemplates={templates}
-            message={message}
+            messageContent={message.message}
+            template={message.messageType}
+            messageId={`${message._id}_${message.message.Reference}`}
             getJsonEditorValue={getJsonEditorValue}
             disabled={true}
             gameDate={gameDate}

--- a/packages/components/src/local/molecules/json-editor/__snapshots__/index.spec.tsx.snap
+++ b/packages/components/src/local/molecules/json-editor/__snapshots__/index.spec.tsx.snap
@@ -1,7 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ChannelMessageDetail: renders correctly 1`] = `
-<div
-  className="edt-disable"
-/>
+<span
+  style={
+    Object {
+      "background": "#ff0",
+      "color": "#f00",
+      "fontSize": "16px",
+      "padding": "20px",
+    }
+  }
+>
+  Schema not found for 
+  CustomMessage
+</span>
 `;

--- a/packages/components/src/local/molecules/json-editor/index.spec.tsx
+++ b/packages/components/src/local/molecules/json-editor/index.spec.tsx
@@ -4,13 +4,15 @@ import renderer from 'react-test-renderer'
 import JsonEditor from './index'
 
 import { MessageTemplatesMockByKey, messageDataCollaborativeEditing, WargameMock } from '@serge/mocks'
-
+const message = messageDataCollaborativeEditing[2]
 describe('ChannelMessageDetail:', () => {
   it('renders correctly', () => {
     const tree = renderer
       .create(<JsonEditor
         messageTemplates={MessageTemplatesMockByKey}
-        message={messageDataCollaborativeEditing[2]}
+        messageContent={message.message}
+        template={message.messageType}
+        messageId={`${message._id}_${message.message.Reference}`}
         disabled={true}
         gameDate={WargameMock.data.overview.gameDate}
       />)

--- a/packages/components/src/local/molecules/json-editor/index.stories-inc.tsx
+++ b/packages/components/src/local/molecules/json-editor/index.stories-inc.tsx
@@ -32,10 +32,9 @@ export default {
   }
 }
 
-
 const Template: Story<Props> = ({ messageTemplates, disabled, template, messageContent, messageId }) => {
   return (
-  <JsonEditor messageId={messageId} template={template} messageContent={messageContent} messageTemplates={messageTemplates} disabled={disabled} gameDate={WargameMock.data.overview.gameDate} />  
+    <JsonEditor messageId={messageId} template={template} messageContent={messageContent} messageTemplates={messageTemplates} disabled={disabled} gameDate={WargameMock.data.overview.gameDate} />
   )
 }
 
@@ -45,7 +44,7 @@ export const Standard = Template.bind({})
 Standard.args = {
   messageContent: testMessage.message,
   messageId: `${testMessage._id}_${testMessage.message.Reference}`,
-  template:  messageDataCollaborativeResponding[0].details.messageType,
+  template: messageDataCollaborativeResponding[0].details.messageType,
   messageTemplates: MessageTemplatesMockByKey,
   disabled: false,
   gameDate: WargameMock.data.overview.gameDate

--- a/packages/components/src/local/molecules/json-editor/index.stories-inc.tsx
+++ b/packages/components/src/local/molecules/json-editor/index.stories-inc.tsx
@@ -6,7 +6,7 @@ import docs from './README.md'
 import { withKnobs } from '@storybook/addon-knobs'
 
 // Import mock
-import { MessageTemplatesMockByKey, messageDataCollaborativeEditing, WargameMock } from '@serge/mocks'
+import { MessageTemplatesMockByKey, WargameMock, messageDataCollaborativeResponding } from '@serge/mocks'
 import { Story } from '@storybook/react/types-6-0'
 
 import Props from './types/props'
@@ -32,19 +32,33 @@ export default {
   }
 }
 
-const Template: Story<Props> = ({ message, messageTemplates, disabled }) => {
+
+const Template: Story<Props> = ({ messageTemplates, disabled, template, messageContent, messageId }) => {
   return (
-    <JsonEditor message={message} messageTemplates={messageTemplates} disabled={disabled} gameDate={WargameMock.data.overview.gameDate} />
+  <JsonEditor messageId={messageId} template={template} messageContent={messageContent} messageTemplates={messageTemplates} disabled={disabled} gameDate={WargameMock.data.overview.gameDate} />  
   )
 }
 
-export const Default = Template.bind({})
+const testMessage = messageDataCollaborativeResponding[0]
 
-const defArgs: Props = {
-  message: messageDataCollaborativeEditing[1],
+export const Standard = Template.bind({})
+Standard.args = {
+  messageContent: testMessage.message,
+  messageId: `${testMessage._id}_${testMessage.message.Reference}`,
+  template:  messageDataCollaborativeResponding[0].details.messageType,
   messageTemplates: MessageTemplatesMockByKey,
   disabled: false,
   gameDate: WargameMock.data.overview.gameDate
 }
 
-Default.args = defArgs
+export const Response = Template.bind({})
+Response.args = {
+  template: 'Chat',
+  messageContent: {
+    content: 'Last message. turn 2 started!'
+  },
+  messageId: Date(),
+  messageTemplates: MessageTemplatesMockByKey,
+  disabled: false,
+  gameDate: WargameMock.data.overview.gameDate
+}

--- a/packages/components/src/local/molecules/json-editor/index.stories-inc.tsx
+++ b/packages/components/src/local/molecules/json-editor/index.stories-inc.tsx
@@ -32,7 +32,12 @@ export default {
   }
 }
 
-const Template: Story<Props> = ({ message, messageTemplates, disabled }) => <JsonEditor message={message} messageTemplates={messageTemplates} disabled={disabled} gameDate={WargameMock.data.overview.gameDate} />
+const Template: Story<Props> = ({ message, messageTemplates, disabled }) => {
+  return (
+    <JsonEditor message={message} messageTemplates={messageTemplates} disabled={disabled} gameDate={WargameMock.data.overview.gameDate} />
+  )
+}
+
 export const Default = Template.bind({})
 
 const defArgs: Props = {

--- a/packages/components/src/local/molecules/json-editor/index.stories-inc.tsx
+++ b/packages/components/src/local/molecules/json-editor/index.stories-inc.tsx
@@ -37,7 +37,7 @@ const storeNewValue = (value: { [property: string]: any }) => {
 
 const Template: Story<Props> = ({ messageTemplates, disabled, template, messageContent, messageId }) => {
   return (
-    <JsonEditor messageId={messageId} template={template} messageContent={messageContent} 
+    <JsonEditor messageId={messageId} template={template} messageContent={messageContent}
       messageTemplates={messageTemplates} disabled={disabled} gameDate={WargameMock.data.overview.gameDate}
       storeNewValue={storeNewValue} />
   )

--- a/packages/components/src/local/molecules/json-editor/index.stories-inc.tsx
+++ b/packages/components/src/local/molecules/json-editor/index.stories-inc.tsx
@@ -31,10 +31,15 @@ export default {
     }
   }
 }
+const storeNewValue = (value: { [property: string]: any }) => {
+  console.log('store data', value)
+}
 
 const Template: Story<Props> = ({ messageTemplates, disabled, template, messageContent, messageId }) => {
   return (
-    <JsonEditor messageId={messageId} template={template} messageContent={messageContent} messageTemplates={messageTemplates} disabled={disabled} gameDate={WargameMock.data.overview.gameDate} />
+    <JsonEditor messageId={messageId} template={template} messageContent={messageContent} 
+      messageTemplates={messageTemplates} disabled={disabled} gameDate={WargameMock.data.overview.gameDate}
+      storeNewValue={storeNewValue} />
   )
 }
 

--- a/packages/components/src/local/molecules/json-editor/index.tsx
+++ b/packages/components/src/local/molecules/json-editor/index.tsx
@@ -15,7 +15,7 @@ import { configDateTimeLocal } from '@serge/helpers'
 const keydowListenFor: string[] = ['TEXTAREA', 'INPUT']
 
 /* Render component */
-export const JsonEditor: React.FC<Props> = ({ messageTemplates, messageId, messageContent, template, getJsonEditorValue, disabled = false, saveEditedMessage = false, expandHeight = true, gameDate, disableArrayToolsWithEditor = true }) => {
+export const JsonEditor: React.FC<Props> = ({ messageTemplates, messageId, messageContent, template, storeNewValue, disabled = false, saveEditedMessage = false, expandHeight = true, gameDate, disableArrayToolsWithEditor = true }) => {
   const jsonEditorRef = useRef<HTMLDivElement>(null)
   const [editor, setEditor] = useState<Editor | null>(null)
 
@@ -35,7 +35,7 @@ export const JsonEditor: React.FC<Props> = ({ messageTemplates, messageId, messa
   }
 
   const handleChange = (value: { [property: string]: any }): void => {
-    getJsonEditorValue && getJsonEditorValue(value)
+    storeNewValue && storeNewValue(value)
   }
 
   const genLocalStorageId = (): string => {

--- a/packages/components/src/local/molecules/json-editor/index.tsx
+++ b/packages/components/src/local/molecules/json-editor/index.tsx
@@ -15,13 +15,14 @@ import { configDateTimeLocal } from '@serge/helpers'
 const keydowListenFor: string[] = ['TEXTAREA', 'INPUT']
 
 /* Render component */
-export const JsonEditor: React.FC<Props> = ({ message, messageTemplates, getJsonEditorValue, disabled = false, saveEditedMessage = false, expandHeight = true, gameDate, disableArrayToolsWithEditor = true }) => {
+export const JsonEditor: React.FC<Props> = ({ messageTemplates, messageId, messageContent, template, getJsonEditorValue, disabled = false, saveEditedMessage = false, expandHeight = true, gameDate, disableArrayToolsWithEditor = true }) => {
   const jsonEditorRef = useRef<HTMLDivElement>(null)
   const [editor, setEditor] = useState<Editor | null>(null)
+
   const schema = Object.keys(messageTemplates).map(
     // TODO: Switch this part to use id instead of messageType find, currently we have no messageTypeId inside of message
     (key): TemplateBody => messageTemplates[key]
-  ).find(msg => msg.title === message.details.messageType)
+  ).find(msg => msg.title === template)
 
   if (!schema) {
     const styles = {
@@ -30,7 +31,7 @@ export const JsonEditor: React.FC<Props> = ({ message, messageTemplates, getJson
       padding: '20px',
       fontSize: '16px'
     }
-    return <span style={styles} >Schema not found for {message.details.messageType}</span>
+    return <span style={styles} >Schema not found for {template}</span>
   }
 
   const handleChange = (value: { [property: string]: any }): void => {
@@ -38,7 +39,7 @@ export const JsonEditor: React.FC<Props> = ({ message, messageTemplates, getJson
   }
 
   const genLocalStorageId = (): string => {
-    return `${message._id}_${message.message.Reference}`
+    return messageId
   }
 
   const initEditor = (): () => void => {
@@ -83,7 +84,7 @@ export const JsonEditor: React.FC<Props> = ({ message, messageTemplates, getJson
 
     if (nextEditor) {
       const messageJson = saveEditedMessage ? expiredStorage.getItem(genLocalStorageId()) : null
-      nextEditor.setValue(typeof messageJson === 'string' ? JSON.parse(messageJson) : message.message)
+      nextEditor.setValue(typeof messageJson === 'string' ? JSON.parse(messageJson) : messageContent)
       nextEditor.on('change', changeListenter)
     }
 

--- a/packages/components/src/local/molecules/json-editor/types/props.d.ts
+++ b/packages/components/src/local/molecules/json-editor/types/props.d.ts
@@ -1,9 +1,17 @@
-import { MessageCustom, TemplateBodysByKey } from '@serge/custom-types'
+import { MessageCustom, MessageStructure, TemplateBodysByKey } from '@serge/custom-types'
 
 export default interface Props {
   onChange?: (nextMessage: MessageCustom) => void
   getJsonEditorValue?: (value: { [property: string]: any }) => void
   message: MessageCustom
+  /** 
+   * content of message
+   */
+  messageContent: MessageStructure
+  /**
+   * template
+   */
+  template: string
   /**
    * dictionary of templates, indexed by template name
    */

--- a/packages/components/src/local/molecules/json-editor/types/props.d.ts
+++ b/packages/components/src/local/molecules/json-editor/types/props.d.ts
@@ -2,8 +2,8 @@ import { MessageCustom, MessageStructure, TemplateBodysByKey } from '@serge/cust
 
 export default interface Props {
   onChange?: (nextMessage: MessageCustom) => void
-  /** 
-   * handler for any text change 
+  /**
+   * handler for any text change
    */
   storeNewValue?: (value: { [property: string]: any }) => void
   /**

--- a/packages/components/src/local/molecules/json-editor/types/props.d.ts
+++ b/packages/components/src/local/molecules/json-editor/types/props.d.ts
@@ -2,7 +2,10 @@ import { MessageCustom, MessageStructure, TemplateBodysByKey } from '@serge/cust
 
 export default interface Props {
   onChange?: (nextMessage: MessageCustom) => void
-  getJsonEditorValue?: (value: { [property: string]: any }) => void
+  /** 
+   * handler for any text change 
+   */
+  storeNewValue?: (value: { [property: string]: any }) => void
   /**
    * content of message
    */

--- a/packages/components/src/local/molecules/json-editor/types/props.d.ts
+++ b/packages/components/src/local/molecules/json-editor/types/props.d.ts
@@ -3,12 +3,12 @@ import { MessageCustom, MessageStructure, TemplateBodysByKey } from '@serge/cust
 export default interface Props {
   onChange?: (nextMessage: MessageCustom) => void
   getJsonEditorValue?: (value: { [property: string]: any }) => void
-  /** 
+  /**
    * content of message
    */
   messageContent: MessageStructure
-  /** 
-   * id for message (used for tracking message read) 
+  /**
+   * id for message (used for tracking message read)
    */
   messageId: string
   /**

--- a/packages/components/src/local/molecules/json-editor/types/props.d.ts
+++ b/packages/components/src/local/molecules/json-editor/types/props.d.ts
@@ -3,11 +3,14 @@ import { MessageCustom, MessageStructure, TemplateBodysByKey } from '@serge/cust
 export default interface Props {
   onChange?: (nextMessage: MessageCustom) => void
   getJsonEditorValue?: (value: { [property: string]: any }) => void
-  message: MessageCustom
   /** 
    * content of message
    */
   messageContent: MessageStructure
+  /** 
+   * id for message (used for tracking message read) 
+   */
+  messageId: string
   /**
    * template
    */


### PR DESCRIPTION
The current json editor knows too much about the structure of `message` objects.

Refactor the `props`, so we can pass in different types of data.