### PR TITLE
Hotfix/title column in coa status board

### DIFF
--- a/packages/components/src/local/coa-status-board/__snapshots__/index.spec.tsx.snap
+++ b/packages/components/src/local/coa-status-board/__snapshots__/index.spec.tsx.snap
@@ -435,7 +435,9 @@ Array [
             >
               <div
                 data-tag="allowRowEvents"
-              />
+              >
+                RFI 3 from Blue
+              </div>
             </div>
             <div
               className="sc-bxivhb sc-ifAKCX sc-EHOje EsLZI rdt_TableCell"
@@ -610,7 +612,9 @@ Array [
             >
               <div
                 data-tag="allowRowEvents"
-              />
+              >
+                RFI 1 from RED
+              </div>
             </div>
             <div
               className="sc-bxivhb sc-ifAKCX sc-EHOje EsLZI rdt_TableCell"

--- a/packages/components/src/local/coa-status-board/helpers/gen-data.tsx
+++ b/packages/components/src/local/coa-status-board/helpers/gen-data.tsx
@@ -211,7 +211,7 @@ export const genData = (
     const row: Row = {
       id: message._id || message.message.Reference,
       from: message.details.from.roleName,
-      tille: message.message.Title,
+      title: message.message.Title,
       status: status,
       owner: ownerComposite,
       updated: moment(lastUpdated).fromNow(),


### PR DESCRIPTION
Hotfix - we were using the wrong prop name for the message title