### PR TITLE
Workaround to remove multiple channels with same id

### DIFF
--- a/packages/client/src/ActionsAndReducers/playerUi/playerUi_Reducer.ts
+++ b/packages/client/src/ActionsAndReducers/playerUi/playerUi_Reducer.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import {
   SET_CURRENT_WARGAME_PLAYER,
   SET_FORCE,
@@ -108,7 +109,16 @@ export const playerUiReducer = (state: PlayerUi = initialState, action: PlayerUi
       newState.turnEndTime = action.payload.turnEndTime || ''
       newState.gameDescription = action.payload.data.overview.gameDescription
       newState.mappingConstaints = action.payload.data.overview.mapConstraints
-      newState.allChannels = action.payload.data.channels.channels || []
+
+      // temporary workaround to remove duplicate channel definitions
+      // TODO: delete workaround once fix in place
+      const allChannels = action.payload.data.channels.channels || []
+      const cleanChannels = _.uniqBy(allChannels, channel => channel.uniqid)
+      if (allChannels.length != cleanChannels.length) {
+        console.warn('Applied workaround to remove duplicate channel defs')
+      }
+      newState.allChannels = cleanChannels
+
       newState.allForces = action.payload.data.forces.forces
       // legacy versions of the wargame used platform_types instead of
       // platformTypes, don't trip over when encountering legacy version


### PR DESCRIPTION
Supports #1442 

Workaround to remove channels with duplicate id. But, this is just a run-time workaround, it doesn't make the problem go away.