### PR TITLE
Hotfix/remove unnecessary mapping fetch calls

### DIFF
--- a/packages/components/src/local/mapping/index.tsx
+++ b/packages/components/src/local/mapping/index.tsx
@@ -143,10 +143,10 @@ export const Mapping: React.FC<PropTypes> = ({
   const [filterHistoryRoutes, setFilterHistoryRoutes] = useState<boolean>(true)
   const [plansSubmitted, setPlansSubmitted] = useState<boolean>(false)
   const [currentPhase, setCurrentPhase] = useState<Phase>(Phase.Adjudication)
-  const [atlanticCells, setAtlanticCells] = useState()
+  const [atlanticCells, setAtlanticCells] = useState<GeoJSON.FeatureCollection>()
   const [polygonAreas, setPolygonAreas] = useState<FeatureCollection<Geometry, GeoJsonProperties> | undefined>(undefined)
   const [cellLabelStyle, setCellLabelStyle] = useState<CellLabelStyle>(CellLabelStyle.H3_LABELS)
-  const [mappingConstraintState] = useState<MappingConstraints | undefined>(mappingConstraints)
+  const [mappingConstraintState] = useState<MappingConstraints>(mappingConstraints)
 
   const domain = (mappingConstraintState && enumFromString(Domain, mappingConstraintState.targetDataset)) || Domain.ATLANTIC
 
@@ -479,6 +479,9 @@ export const Mapping: React.FC<PropTypes> = ({
   }
 
   const calcDistanceBetweenCentresM = (): number => {
+    if (!mappingConstraintState) {
+      throw new Error('Cannot calculate distance without mapping constraints')
+    }
     const minsToM = (mins: number): number => {
       return mins * 1862
     }

--- a/packages/custom-types/mapping-context.d.ts
+++ b/packages/custom-types/mapping-context.d.ts
@@ -2,6 +2,7 @@ import { Phase, Domain, CellLabelStyle } from '@serge/config'
 import PlanMobileAsset from './plan-mobile-asset'
 import SelectedAsset from './selected-asset'
 import { RouteStore, PlanTurnFormValues, MapPostBack, NewTurnValues, ForceData, PlatformTypeData, SergeGrid3 } from '.'
+import { FeatureCollection, GeoJsonProperties, Geometry } from 'geojson'
 
 /**
  * mapping context, shared with child elements
@@ -154,7 +155,7 @@ export default interface MappingContext {
   /**
    * series of polygon areas, to be shaded
    */
-  polygonAreas?: any
+  polygonAreas?: FeatureCollection<Geometry, GeoJsonProperties>
   /** how to format the cell labels */
   cellLabelStyle?: CellLabelStyle
   /** 


### PR DESCRIPTION
We were getting unnecessary attempts to download mapping datafiles.

Have put `mappingConstraints` into state