### PR TITLE
Browser doesn't like a <div> falling inside a <p>

### DIFF
--- a/packages/client/src/Views/PlayerUiLandingScreen.tsx
+++ b/packages/client/src/Views/PlayerUiLandingScreen.tsx
@@ -36,7 +36,7 @@ const PlayerUiLandingScreen: React.FC<Props> = ({ gameInfo, enterSerge }) => {
         <div className="welcome-desc">
           <p>{title}</p>
           <p>Welcome!</p>
-          <p>{lineBreak(gameInfo.description)}</p>
+          {lineBreak(gameInfo.description)}
           <button name="play" className="btn btn-action btn-action--primary" onClick={enterSerge}>Play</button>
         </div>
       </div>


### PR DESCRIPTION
The `lineBreak` command generates `<div>` elements for line breaks.  But, the browser doesn't like `<div>` elements falling inside a `<p>`.

This fixes that.