### PR TITLE
don't cancel listener if document was initial wargame

### DIFF
--- a/packages/client/src/api/db/index.tsx
+++ b/packages/client/src/api/db/index.tsx
@@ -3,7 +3,9 @@ import {
   databasePath,
   socketPath,
   replicate,
-  deletePath
+  deletePath,
+  wargameSettings,
+  settings
 } from '@serge/config'
 import { Message, MessageCustom, Wargame } from '@serge/custom-types'
 import { io } from 'socket.io-client'
@@ -31,8 +33,10 @@ export class DbProvider implements DbProviderInterface {
   changes (listener: (doc: Message) => void): void {
     const socket = io(socketPath)
     const listenerMessage = (data: MessageCustom) => {
+      // we use two special names for the wargame document
+      const specialFiles = [wargameSettings, settings]
       // have we just received this message?
-      if ((data._id !== 'initial_wargame') && (this.message_ID === data._id)) {
+      if (!specialFiles.includes(data._id) && (this.message_ID === data._id)) {
         // yes - stop listening on this socket
         console.warn('stopping listening for', data._id)
         socket.off('changes', listenerMessage) 

--- a/packages/client/src/api/db/index.tsx
+++ b/packages/client/src/api/db/index.tsx
@@ -32,8 +32,9 @@ export class DbProvider implements DbProviderInterface {
     const socket = io(socketPath)
     const listenerMessage = (data: MessageCustom) => {
       // have we just received this message?
-      if (this.message_ID === data._id) {
+      if ((data._id !== 'initial_wargame') && (this.message_ID === data._id)) {
         // yes - stop listening on this socket
+        console.warn('stopping listening for', data._id)
         socket.off('changes', listenerMessage) 
       } else {
         // no, handle the message


### PR DESCRIPTION
Fixes issue where Serge client would randomly stop listening for changes.

@lilitkarapetyan - are you ok with this?

`initial-document` is a _Special_ phrase that we don't use as a test for duplicate message.  Right?