### PR TITLE
Improve test for if this is a message

### DIFF
--- a/packages/helpers/src/most-recent-only.ts
+++ b/packages/helpers/src/most-recent-only.ts
@@ -6,7 +6,7 @@ import { MessageChannel } from '@serge/custom-types'
  */
 const getIDs = (message: MessageChannel): string => {
   let res
-  if (message.messageType === INFO_MESSAGE_CLIPPED || message.infoType === true) {
+  if (message.messageType === INFO_MESSAGE_CLIPPED || message.infoType === true || message.message === undefined) {
     res = '' + message.gameTurn
   } else {
     const msg = message.message


### PR DESCRIPTION
Fixes emergent bug where `most-recent-only` method fails when it encounters a wargame without an `infoType` message marker.

![image](https://user-images.githubusercontent.com/1108513/180748736-be188f05-ed5d-44ef-8cef-9d8d6cc84b2f.png)
