### PR TITLE
Hotfix forces in laydown

### DIFF
--- a/packages/components/src/local/assets/index.tsx
+++ b/packages/components/src/local/assets/index.tsx
@@ -79,7 +79,10 @@ export const Assets: React.FC<{}> = () => {
         if (perceivedAsTypes && perceivedAsTypes.typeId) {
           const assetInLaydown = route.laydownPhase === LaydownPhases.Unmoved
           if (!route.currentLocation2 && !assetInLaydown) {
-            console.warn('Warning: location missing for asset that isn\'t in laydown', route.name)
+            console.warn('Warning: location missing for asset that isn\'t in laydown:', route.name, ' This may be because we\'re mid-update')
+          }
+          if (assetInLaydown && (route.currentLocation2 !== undefined)) {
+            console.warn('Unmoved asset doesn\'t have location as pending')
           }
           const position: L.LatLng | undefined = route.currentLocation2 || dummyLocation
 

--- a/packages/components/src/local/assets/index.tsx
+++ b/packages/components/src/local/assets/index.tsx
@@ -78,7 +78,7 @@ export const Assets: React.FC<{}> = () => {
 
         if (perceivedAsTypes && perceivedAsTypes.typeId) {
           const assetInLaydown = route.laydownPhase === LaydownPhases.Unmoved
-          if(!route.currentLocation2 && !assetInLaydown) {
+          if (!route.currentLocation2 && !assetInLaydown) {
             console.warn('Warning: location missing for asset that isn\'t in laydown', route.name)
           }
           const position: L.LatLng | undefined = route.currentLocation2 || dummyLocation
@@ -123,7 +123,7 @@ export const Assets: React.FC<{}> = () => {
               }
               tmpAssets.push(assetInfo)
             } else {
-              console.warn('Failed to find force that controls', route.name)              
+              console.warn('Failed to find force that controls', route.name)
             }
           } else {
             console.log('!! Failed to find cell numbered:', position, route.currentPosition, route.name)

--- a/packages/components/src/local/assets/index.tsx
+++ b/packages/components/src/local/assets/index.tsx
@@ -79,7 +79,7 @@ export const Assets: React.FC<{}> = () => {
         if (perceivedAsTypes && perceivedAsTypes.typeId) {
           const assetInLaydown = route.laydownPhase === LaydownPhases.Unmoved
           if(!route.currentLocation2 && !assetInLaydown) {
-            console.warn('Warning: location missing for asset that isn\'t in laydown')
+            console.warn('Warning: location missing for asset that isn\'t in laydown', route.name)
           }
           const position: L.LatLng | undefined = route.currentLocation2 || dummyLocation
 

--- a/packages/components/src/local/assets/index.tsx
+++ b/packages/components/src/local/assets/index.tsx
@@ -53,6 +53,9 @@ export const Assets: React.FC<{}> = () => {
   useEffect(() => {
     if (h3gridCells) {
       const tmpAssets: AssetInfo[] = []
+
+      // we may need to provide location for assets that are in laydown
+      const dummyLocation = L.latLng(12.2, 13.3)
       viewAsRouteStore.routes.forEach((route: RouteType) => {
         const { uniqid, name, platformTypeId, actualForceId, condition, laydownPhase, visibleToThisForce, attributes } = route
 
@@ -74,14 +77,16 @@ export const Assets: React.FC<{}> = () => {
         )
 
         if (perceivedAsTypes && perceivedAsTypes.typeId) {
-          const position: L.LatLng | undefined = route.currentLocation2
+          const assetInLaydown = route.laydownPhase === LaydownPhases.Unmoved
+          if(!route.currentLocation2 && !assetInLaydown) {
+            console.warn('Warning: location missing for asset that isn\'t in laydown')
+          }
+          const position: L.LatLng | undefined = route.currentLocation2 || dummyLocation
+
           const visibleToArr: string[] = visibleTo(perceptions)
-          if (position != null) {
+          if (position != null || route.currentPosition === 'pending') {
             // sort out who can control this force
             const assetForce: ForceData | undefined = forces.find((force: ForceData) => force.uniqid === actualForceId)
-
-            // console.log('percy', perceivedAsTypes, position, !!assetForce, actualForceId)
-
             if (assetForce) {
               const isSelected: boolean = selectedAsset !== undefined ? uniqid === selectedAsset.uniqid : false
               const orientData: OrientationData[] = []
@@ -117,6 +122,8 @@ export const Assets: React.FC<{}> = () => {
                 orientationData: orientData
               }
               tmpAssets.push(assetInfo)
+            } else {
+              console.warn('Failed to find force that controls', route.name)              
             }
           } else {
             console.log('!! Failed to find cell numbered:', position, route.currentPosition, route.name)

--- a/packages/helpers/src/route-declutter.ts
+++ b/packages/helpers/src/route-declutter.ts
@@ -50,7 +50,7 @@ const findLocations = (routes: RouteStore, markers: MapAnnotations, selected: st
   // loop through store
   routes.routes && routes.routes.forEach((route: Route) => {
     // start with location
-    if (route.currentPosition) {
+    if (route.currentPosition && route.currentPosition !== 'pending') {
       const updateAssetLocation: ClusterSetter = (newLoc: L.LatLng): void => {
         route.currentLocation2 = newLoc
       }


### PR DESCRIPTION
Fix to issue that made the last "Umpire Laydown" asset disappear.

Issue was related to both declutter algorithm mistakenly distributing assets with position as "pending", and the assets renderer not processing pending assets that were waiting for a location.