### PR TITLE
Update css props

### DIFF
--- a/packages/components/src/local/atoms/message-label/index.tsx
+++ b/packages/components/src/local/atoms/message-label/index.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import { makeStyles, createStyles, Theme, fade } from '@material-ui/core/styles'
+import { makeStyles, createStyles, Theme, alpha } from '@material-ui/core/styles'
 import Chip, { ChipProps } from '@material-ui/core/Chip'
 
 /* Render component */
 const useMessageLabelStyle = makeStyles((theme: Theme) =>
   createStyles({
     root: () => ({
-      backgroundColor: fade(theme.palette.common.white, 0.25),
+      backgroundColor: alpha(theme.palette.common.white, 0.25),
       borderRadius: 2
     }),
     sizeSmall: {

--- a/packages/components/src/local/atoms/text-input/index.stories.tsx
+++ b/packages/components/src/local/atoms/text-input/index.stories.tsx
@@ -34,7 +34,7 @@ const rowValues = {
 
 export const FilledWithLabelTwoRows: React.FC = () => <TextInput multiline={boolean('Multi-Line', true)} fullWidth rows={number('Rows', 2, rowValues)} variant="filled" label="Enter a value" labelColor="common.white" labelSize={12} />
 
-export const FilledWithLabelTwoRowsMaxFour: React.FC = () => <TextInput fullWidth={boolean('Full-width', false)} multiline={boolean('Multi-Line', true)} rows={number('Rows', 2, rowValues)} rowsMax={number('Max rows', 4, rowValues)} variant="filled" label="Enter a value" labelColor="common.white" labelSize={12} />
+export const FilledWithLabelTwoRowsMaxFour: React.FC = () => <TextInput fullWidth={boolean('Full-width', false)} multiline={boolean('Multi-Line', true)} rows={number('Rows', 2, rowValues)} maxRows={number('Max rows', 4, rowValues)} variant="filled" label="Enter a value" labelColor="common.white" labelSize={12} />
 
 // @ts-ignore TS believes the 'story' property doesn't exist but it does.
 Default.story = {

--- a/packages/components/src/local/atoms/text-input/index.tsx
+++ b/packages/components/src/local/atoms/text-input/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { kebabCase } from 'lodash'
-import { FilledInputProps, TextField, fade } from '@material-ui/core'
+import { FilledInputProps, TextField, alpha } from '@material-ui/core'
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles'
 import InputContainer from '../input-container'
 
@@ -13,13 +13,13 @@ const useFilledStyle = makeStyles<Theme>((theme) =>
       backgroundColor: theme.palette.common.white,
       borderRadius: '8px',
       '&.Mui-focused': {
-        backgroundColor: fade(theme.palette.common.white, 0.75)
+        backgroundColor: alpha(theme.palette.common.white, 0.75)
       },
       '&:hover': {
-        backgroundColor: fade(theme.palette.common.white, 0.75)
+        backgroundColor: alpha(theme.palette.common.white, 0.75)
       },
       '&:focus': {
-        backgroundColor: fade(theme.palette.common.white, 0.95)
+        backgroundColor: alpha(theme.palette.common.white, 0.95)
       }
     },
     input: {
@@ -71,7 +71,7 @@ export const TextInput: React.FC<PropTypes> = ({
   value,
   multiline,
   rows,
-  rowsMax,
+  maxRows,
   updateState,
   className,
   placeholder,
@@ -122,7 +122,7 @@ export const TextInput: React.FC<PropTypes> = ({
         {...{
           multiline,
           rows,
-          rowsMax,
+          maxRows,
           name: inputName,
           value: inputValue,
           onChange: handleChange,

--- a/packages/components/src/local/atoms/text-input/index.tsx
+++ b/packages/components/src/local/atoms/text-input/index.tsx
@@ -70,7 +70,7 @@ export const TextInput: React.FC<PropTypes> = ({
   variant,
   value,
   multiline,
-  minRows,
+  rows,
   maxRows,
   updateState,
   className,
@@ -121,7 +121,7 @@ export const TextInput: React.FC<PropTypes> = ({
         } as Partial<FilledInputProps>}
         {...{
           multiline,
-          minRows,
+          rows,
           maxRows,
           name: inputName,
           value: inputValue,

--- a/packages/components/src/local/atoms/text-input/index.tsx
+++ b/packages/components/src/local/atoms/text-input/index.tsx
@@ -70,7 +70,7 @@ export const TextInput: React.FC<PropTypes> = ({
   variant,
   value,
   multiline,
-  rows,
+  minRows,
   maxRows,
   updateState,
   className,
@@ -121,7 +121,7 @@ export const TextInput: React.FC<PropTypes> = ({
         } as Partial<FilledInputProps>}
         {...{
           multiline,
-          rows,
+          minRows,
           maxRows,
           name: inputName,
           value: inputValue,

--- a/packages/components/src/local/atoms/text-input/types/props.d.ts
+++ b/packages/components/src/local/atoms/text-input/types/props.d.ts
@@ -66,7 +66,7 @@ export type PropTypes = TextFieldProps & {
   /**
    * Multiline maximum rows length
    */
-  rowsMax?: number
+  maxRows?: number
   /**
    * Is the field input being used as section title as well?
    */

--- a/packages/components/src/local/form-elements/chat-input-text/index.tsx
+++ b/packages/components/src/local/form-elements/chat-input-text/index.tsx
@@ -25,10 +25,10 @@ export const ChatInputText: React.FC<Props> = React.forwardRef(({ placeholder, p
   }
 
   useImperativeHandle(ref, () => ({
-    setFormState (text: string): void {
+    setFormState(text: string): void {
       setFormState(text)
     },
-    clear (): void {
+    clear(): void {
       setFormState('')
     }
   }))
@@ -43,7 +43,7 @@ export const ChatInputText: React.FC<Props> = React.forwardRef(({ placeholder, p
     <TextInput
       fullWidth
       multiline
-      rows={2}
+      minRows={2}
       maxRows={3}
       variant="filled"
       updateState={changeHandler}

--- a/packages/components/src/local/form-elements/chat-input-text/index.tsx
+++ b/packages/components/src/local/form-elements/chat-input-text/index.tsx
@@ -44,7 +44,7 @@ export const ChatInputText: React.FC<Props> = React.forwardRef(({ placeholder, p
       fullWidth
       multiline
       rows={2}
-      rowsMax={3}
+      maxRows={3}
       variant="filled"
       updateState={changeHandler}
       value={formState}

--- a/packages/components/src/local/form-elements/private-chat-input-toggle/index.tsx
+++ b/packages/components/src/local/form-elements/private-chat-input-toggle/index.tsx
@@ -18,10 +18,10 @@ export const PrivateChatInputToggle: React.FC<Props> = React.forwardRef(({ place
   const [collapsed, setCollapsed] = useState(false)
 
   useImperativeHandle(ref, () => ({
-    setFormState (text: string): void {
+    setFormState(text: string): void {
       setFormState(text)
     },
-    clear (): void {
+    clear(): void {
       setFormState('')
     }
   }))
@@ -66,7 +66,7 @@ export const PrivateChatInputToggle: React.FC<Props> = React.forwardRef(({ place
         <TextInput
           fullWidth
           multiline
-          rows={2}
+          minRows={2}
           maxRows={3}
           variant="filled"
           updateState={changeHandler}

--- a/packages/components/src/local/form-elements/private-chat-input-toggle/index.tsx
+++ b/packages/components/src/local/form-elements/private-chat-input-toggle/index.tsx
@@ -67,7 +67,7 @@ export const PrivateChatInputToggle: React.FC<Props> = React.forwardRef(({ place
           fullWidth
           multiline
           rows={2}
-          rowsMax={3}
+          maxRows={3}
           variant="filled"
           updateState={changeHandler}
           value={formState}

--- a/packages/components/src/local/marker-form/index.tsx
+++ b/packages/components/src/local/marker-form/index.tsx
@@ -104,7 +104,7 @@ export const MarkerForm: React.FC<PropTypes> = ({ formData, updateMarker, closeF
     </TitleWithIcon>
     <fieldset className={styles.fieldset}>
       <div className={styles.description}>
-        <TextField InputProps={{ disableUnderline: true }} fullWidth multiline rowsMax={2} placeholder={'Description'} value={formState.description} onInput={onDescriptionChange} />
+        <TextField InputProps={{ disableUnderline: true }} fullWidth multiline maxRows={2} placeholder={'Description'} value={formState.description} onInput={onDescriptionChange} />
       </div>
       <FormGroup title='icon type' align='right'>
         <Selector label="" name='iconType' options={icons} selected={formState.iconId} updateState={typeHandler} className={styles['input-container']} selectClassName={styles.select} />

--- a/packages/components/src/local/message-creator/index.tsx
+++ b/packages/components/src/local/message-creator/index.tsx
@@ -47,7 +47,7 @@ export const MessageCreator: React.FC<Props> = ({ from, channel, role, roleName,
   }
 
   return <div>
-    <TextInput label="Post message" name="Message" multiline rowsMax={4} updateState={changeHandler} value={formState}/>
+    <TextInput label="Post message" name="Message" multiline maxRows={4} updateState={changeHandler} value={formState}/>
     <Button onClick={submitForm}>Send</Button>
   </div>
 }

--- a/packages/components/src/local/molecules/admin-message-creator/index.tsx
+++ b/packages/components/src/local/molecules/admin-message-creator/index.tsx
@@ -54,7 +54,7 @@ export const AdminMessageCreator: React.FC<Props> = ({ from, channel, role, role
         <TextInput
           name="Message"
           multiline
-          rowsMax={4}
+          maxRows={4}
           updateState={changeHandler}
           value={formState}
           fullWidth

--- a/packages/components/src/local/molecules/insight-form/index.tsx
+++ b/packages/components/src/local/molecules/insight-form/index.tsx
@@ -39,7 +39,7 @@ export const InsightForm: React.FC<Props> = ({ onCancel, onSend, darkMode }: Pro
         <TextInput
           multiline
           fullWidth
-          minRows={4}
+          rows={4}
           label="Message"
           labelSize={12}
           labelColor={darkMode ? 'common.white' : 'common.black'}

--- a/packages/components/src/local/molecules/insight-form/index.tsx
+++ b/packages/components/src/local/molecules/insight-form/index.tsx
@@ -39,7 +39,7 @@ export const InsightForm: React.FC<Props> = ({ onCancel, onSend, darkMode }: Pro
         <TextInput
           multiline
           fullWidth
-          rows={4}
+          minRows={4}
           label="Message"
           labelSize={12}
           labelColor={darkMode ? 'common.white' : 'common.black'}

--- a/packages/components/src/local/organisms/setting-forces/settings-force-overview/index.tsx
+++ b/packages/components/src/local/organisms/setting-forces/settings-force-overview/index.tsx
@@ -60,7 +60,7 @@ export const SettingsForceOverview: FC<PropTypes> = ({ data, handleChangeForce }
                     fullWidth
                     variant="filled"
                     rows={8}
-                    rowsMax={8}
+                    maxRows={8}
                     updateState={(target: { value: string }): void => {
                       handleChangeForce({ ...data, overview: target.value })
                     }}

--- a/packages/components/src/local/organisms/setting-forces/settings-force-overview/index.tsx
+++ b/packages/components/src/local/organisms/setting-forces/settings-force-overview/index.tsx
@@ -59,7 +59,7 @@ export const SettingsForceOverview: FC<PropTypes> = ({ data, handleChangeForce }
                     multiline
                     fullWidth
                     variant="filled"
-                    rows={8}
+                    minRows={8}
                     maxRows={8}
                     updateState={(target: { value: string }): void => {
                       handleChangeForce({ ...data, overview: target.value })

--- a/packages/components/src/local/organisms/setting-overview/index.tsx
+++ b/packages/components/src/local/organisms/setting-overview/index.tsx
@@ -186,7 +186,7 @@ export const SettingOverview: React.FC<PropTypes> = ({
             value={overview.gameDescription}
             variant="filled"
             rows={8}
-            rowsMax={8}
+            maxRows={8}
             updateState={updateGameDescription}
             className={styles.textarea}
           />

--- a/packages/components/src/local/organisms/setting-overview/index.tsx
+++ b/packages/components/src/local/organisms/setting-overview/index.tsx
@@ -165,7 +165,7 @@ export const SettingOverview: React.FC<PropTypes> = ({
 
   return <div className={styles.main}>
     <div className={styles.row}>
-      <div className={styles.col}/>
+      <div className={styles.col} />
       <div className={styles.actions}>
         <Button
           color="secondary"
@@ -185,7 +185,7 @@ export const SettingOverview: React.FC<PropTypes> = ({
             fullWidth
             value={overview.gameDescription}
             variant="filled"
-            rows={8}
+            minRows={8}
             maxRows={8}
             updateState={updateGameDescription}
             className={styles.textarea}
@@ -213,7 +213,7 @@ export const SettingOverview: React.FC<PropTypes> = ({
           </div>
           <div className={styles.group}>
             <label className={styles.label} htmlFor='gameTurnTime'>
-              Wargame turn time<br/>(YY MM DD HH MM SS)
+              Wargame turn time<br />(YY MM DD HH MM SS)
             </label>
             <div className='MuiInputBase-root MuiInput-root MuiInput-underline'>
               {<MaskedInput
@@ -290,7 +290,7 @@ export const SettingOverview: React.FC<PropTypes> = ({
             </div>
           </div>
 
-          <div className={styles.hidden}><Input/></div>
+          <div className={styles.hidden}><Input /></div>
           <div>
             <MoreInfo description='Show clickable lists of roles per force, allowing login without use of per-role passcodes'><FormControlLabel
               control={
@@ -322,9 +322,9 @@ export const SettingOverview: React.FC<PropTypes> = ({
                 initiateWargame && initiateWargame()
               }}>Initiate Wargame</Button>
             }{
-              wargameInitiated &&
-              <p><FontAwesomeIcon icon={faCheck} size="2x" />&nbsp;Wargame initiated</p>
-            }
+                wargameInitiated &&
+                <p><FontAwesomeIcon icon={faCheck} size="2x" />&nbsp;Wargame initiated</p>
+              }
             </>
           </div>
         </FormGroup>


### PR DESCRIPTION
Small changes, to reduce CSS-related compiler warnings

There's still one error: `rows` should be changed to `minRows` - but our UI kit wants `rows`.