### PR TITLE
Hotfix - use valid platform-type values

### DIFF
--- a/packages/components/src/local/map-bar/index.tsx
+++ b/packages/components/src/local/map-bar/index.tsx
@@ -103,13 +103,13 @@ export const MapBar: React.FC = () => {
     setUserIsUmpire(playerForce === UMPIRE_FORCE)
   }, [playerForce])
 
-    // sort out the handler for State of World button
-    useEffect(() => {
-      const tgType = platforms.find((pType: PlatformTypeData) => pType.name === TASK_GROUP)
-      if (tgType) {
-        setTaskGroupType(tgType)
-      }
-    }, [platforms])
+  // sort out the handler for State of World button
+  useEffect(() => {
+    const tgType = platforms.find((pType: PlatformTypeData) => pType.name === TASK_GROUP)
+    if (tgType) {
+      setTaskGroupType(tgType)
+    }
+  }, [platforms])
 
   // sort out the handler for State of World button
   useEffect(() => {

--- a/packages/components/src/local/map-bar/index.tsx
+++ b/packages/components/src/local/map-bar/index.tsx
@@ -22,9 +22,10 @@ import {
   MessageSubmitPlans,
   MessageForceLaydown,
   MessageDeletePlatform,
-  MapAnnotation
+  MapAnnotation,
+  PlatformTypeData
 } from '@serge/custom-types'
-import { Phase, ADJUDICATION_PHASE, UMPIRE_FORCE, PLANNING_PHASE, DELETE_PLATFORM, SUBMIT_PLANS, STATE_OF_WORLD, FORCE_LAYDOWN, PlanningStates, UNKNOWN_TYPE, UPDATE_MARKER, DELETE_MARKER, LaydownTypes, UMPIRE_LAYDOWN } from '@serge/config'
+import { Phase, ADJUDICATION_PHASE, UMPIRE_FORCE, PLANNING_PHASE, DELETE_PLATFORM, SUBMIT_PLANS, STATE_OF_WORLD, FORCE_LAYDOWN, PlanningStates, UNKNOWN_TYPE, UPDATE_MARKER, DELETE_MARKER, LaydownTypes, UMPIRE_LAYDOWN, TASK_GROUP } from '@serge/config'
 
 /* Import Stylesheet */
 import styles from './styles.module.scss'
@@ -60,6 +61,7 @@ export const MapBar: React.FC = () => {
   const [canSubmitOrdersForThisAsset, setCanSubmitOrdersForThisAsset] = useState<boolean>(false)
 
   const [adjudicationManager, setAdjudicationManager] = useState<AdjudicationManager | undefined>(undefined)
+  const [taskGroupType, setTaskGroupType] = useState<PlatformTypeData | undefined>(undefined)
 
   /* Pull in the context from MappingContext */
   const props = useContext(MapContext).props
@@ -100,6 +102,14 @@ export const MapBar: React.FC = () => {
   useEffect(() => {
     setUserIsUmpire(playerForce === UMPIRE_FORCE)
   }, [playerForce])
+
+    // sort out the handler for State of World button
+    useEffect(() => {
+      const tgType = platforms.find((pType: PlatformTypeData) => pType.name === TASK_GROUP)
+      if (tgType) {
+        setTaskGroupType(tgType)
+      }
+    }, [platforms])
 
   // sort out the handler for State of World button
   useEffect(() => {
@@ -378,7 +388,7 @@ export const MapBar: React.FC = () => {
         const actualAsset = findAsset(forces, selectedAsset.uniqid)
         // is this an empty task group?
         const emptyVessel = !actualAsset.comprising || actualAsset.comprising.length === 0
-        const deleteHandler = (actualAsset.platformType === 'task-group' && emptyVessel)
+        const deleteHandler = (taskGroupType && actualAsset.platformTypeId === taskGroupType.uniqid && emptyVessel)
           ? deleteEmptyTaskGroup : undefined
         return <PlanTurnForm
           icon={iconData}

--- a/packages/custom-types/asset.d.ts
+++ b/packages/custom-types/asset.d.ts
@@ -31,10 +31,6 @@ export interface Asset {
    */
   condition: string,
   /** 
-   * the type of this platform. To be @deprecated
-   */
-  platformType?: string,
-  /** 
    * the type-id of this platform 
    */
   platformTypeId: PlatformTypeData['uniqid']

--- a/packages/custom-types/participant.d.ts
+++ b/packages/custom-types/participant.d.ts
@@ -10,7 +10,7 @@ export interface ParticipantTemplate {
 
 /** core properties for a participant */
 export interface CoreParticipant {
-  // Name of force being referred to
+  // Name of force being referred to @deprecated
   readonly force: ForceData['name'],
   readonly forceUniqid: ForceData['uniqid'],
   // specific set of roles that participate in this channel (or empty for all roles)

--- a/packages/custom-types/perception.d.ts
+++ b/packages/custom-types/perception.d.ts
@@ -9,7 +9,7 @@ export default interface Perception {
    /**
    *  the force this force thiks the asset belongs to
    */
-  forceId?: ForceData['uniqid'],
+  force?: ForceData['uniqid'],
   /** 
    * the platform-type this force thinks the asset is 
   */

--- a/packages/custom-types/perception.d.ts
+++ b/packages/custom-types/perception.d.ts
@@ -9,7 +9,7 @@ export default interface Perception {
    /**
    *  the force this force thiks the asset belongs to
    */
-  force?: ForceData['uniqid'],
+  forceId?: ForceData['uniqid'],
   /** 
    * the platform-type this force thinks the asset is 
   */

--- a/packages/helpers/src/create-asset-based-on-platform-type.ts
+++ b/packages/helpers/src/create-asset-based-on-platform-type.ts
@@ -31,7 +31,6 @@ export const createAssetBasedOnPlatformType = (pType: PlatformTypeData): Asset =
     uniqid: uniqid,
     contactId: contactId,
     name: pType.name,
-    platformType: pType.name,
     platformTypeId: pType.uniqid,
     perceptions: [],
     condition: '',

--- a/packages/helpers/src/put-dragged-assets-to-target.ts
+++ b/packages/helpers/src/put-dragged-assets-to-target.ts
@@ -1,5 +1,4 @@
 import { Asset, PlatformTypeData } from '@serge/custom-types'
-import { TASK_GROUP } from '@serge/config'
 
 const putDraggedAssetsToTarget = (targetId: string, asset: Asset, assets: Asset[], isHosting = true, taskGroupType: PlatformTypeData): Asset[] => {
   return assets.map((assetItem: Asset) => {
@@ -8,7 +7,7 @@ const putDraggedAssetsToTarget = (targetId: string, asset: Asset, assets: Asset[
         if (!assetItem.hosting) assetItem.hosting = []
         assetItem.hosting.push(asset)
       } else {
-        if (assetItem.platformType === TASK_GROUP) {
+        if (assetItem.platformTypeId === taskGroupType.uniqid) {
           if (!assetItem.comprising) assetItem.comprising = []
           assetItem.comprising.push(asset)
         } else {
@@ -21,7 +20,6 @@ const putDraggedAssetsToTarget = (targetId: string, asset: Asset, assets: Asset[
             comprising: [asset, assetItem],
             name: groupId,
             perceptions: [],
-            platformType: taskGroupType.name,
             platformTypeId: taskGroupType.uniqid,
             position: assetItem.position,
             status: {

--- a/packages/helpers/src/tests/handle-visibility-condition-changes.spec.ts
+++ b/packages/helpers/src/tests/handle-visibility-condition-changes.spec.ts
@@ -50,7 +50,6 @@ const allForces: ForceData[] = [
       {
         condition: 'Full capability',
         contactId: 'C713',
-        platformType: 'Unmanned-Airborne-Vehicle',
         platformTypeId: 'a10',
         uniqid: 'C01',
         name: 'alpha',
@@ -59,7 +58,6 @@ const allForces: ForceData[] = [
       {
         condition: 'Full capability',
         contactId: 'C723',
-        platformType: 'Unmanned-Airborne-Vehicle',
         platformTypeId: 'a10',
         name: 'bravo',
         uniqid: 'C02',
@@ -80,7 +78,6 @@ const allForces: ForceData[] = [
       {
         condition: 'Full capability',
         contactId: 'C733',
-        platformType: 'Unmanned-Airborne-Vehicle',
         platformTypeId: 'a10',
         name: 'charlie',
         uniqid: 'C03',
@@ -89,7 +86,6 @@ const allForces: ForceData[] = [
       {
         condition: 'Full capability',
         contactId: 'C813',
-        platformType: 'Unmanned-Airborne-Vehicle',
         platformTypeId: 'a10',
         name: 'delta',
         uniqid: 'C04',
@@ -110,7 +106,6 @@ const allForces: ForceData[] = [
       {
         condition: 'Full capability',
         contactId: 'C743',
-        platformType: 'Unmanned-Airborne-Vehicle',
         platformTypeId: 'a10',
         name: 'echo',
         uniqid: 'C05',
@@ -119,7 +114,6 @@ const allForces: ForceData[] = [
       {
         condition: 'Disabled',
         contactId: 'C715',
-        platformType: 'Unmanned-Airborne-Vehicle',
         platformTypeId: 'a10',
         uniqid: 'C06',
         name: 'foxtrot',

--- a/packages/mocks/atlantic-forces.mock.ts
+++ b/packages/mocks/atlantic-forces.mock.ts
@@ -42,7 +42,6 @@ export const forces: ForceData[] = [
                   }
                 ],
                 "plannedTurns": [],
-                "platformType": "Unmanned-Airborne-Vehicle",
                 "platformTypeId" : "a10",
                 "status": {
                   "state": "Landed"
@@ -56,7 +55,6 @@ export const forces: ForceData[] = [
                 "name": "Dart 46",
                 "perceptions": [],
                 "plannedTurns": [],
-                "platformType": "Unmanned-Airborne-Vehicle",
                 "platformTypeId" : "a10",
                 "status": {
                   "state": "Landed"
@@ -72,7 +70,6 @@ export const forces: ForceData[] = [
                 "name": "Frigate A Perceived Name"
               }
             ],
-            "platformType": "frigate",
             "platformTypeId" : "a3",
             "uniqid": "a0prbr6441"
           },
@@ -82,7 +79,6 @@ export const forces: ForceData[] = [
             "history": [],
             "name": "MCM Delta",
             "perceptions": [],
-            "platformType": "MCMV",
             "platformTypeId" : "a7",
             "uniqid": "a0traa6790"
           }
@@ -146,7 +142,6 @@ export const forces: ForceData[] = [
             "turn": 5
           }
         ],
-        "platformType": "task-group",
         "platformTypeId" : "a11",
         "position": "8318adfffffffff",
         "status": {
@@ -182,7 +177,6 @@ export const forces: ForceData[] = [
               }
             ],
             "plannedTurns": [],
-            "platformType": "helicopter",
             "platformTypeId" : "a8",
             "status": {
               "state": "Landed"
@@ -196,7 +190,6 @@ export const forces: ForceData[] = [
             "name": "Dart 42",
             "perceptions": [],
             "plannedTurns": [],
-            "platformType": "Unmanned-Airborne-Vehicle",
             "platformTypeId" : "a10",
             "status": {
               "state": "Landed"
@@ -235,7 +228,6 @@ export const forces: ForceData[] = [
             "turn": 5
           }
         ],
-        "platformType": "frigate",
         "platformTypeId" : "a3",
         "position": "8318a3fffffffff",
         "status": {
@@ -251,7 +243,6 @@ export const forces: ForceData[] = [
         "name": "MPA",
         "perceptions": [],
         "plannedTurns": [],
-        "platformType": "fixed-wing-aircraft",
         "platformTypeId" : "a9",
         "position": "831976fffffffff",
         "status": {
@@ -302,7 +293,6 @@ export const forces: ForceData[] = [
             "turn": 5
           }
         ],
-        "platformType": "merchant-vessel",
         "platformTypeId" : "a13",
         "position": "83181cfffffffff",
         "status": {
@@ -372,7 +362,6 @@ export const forces: ForceData[] = [
             "turn": 4
           }
         ],
-        "platformType": "fishing-vessel",
         "platformTypeId" : "a1",
         "position": "830932fffffffff",
         "status": {
@@ -404,7 +393,6 @@ export const forces: ForceData[] = [
             "name": "Bog Draft",
             "perceptions": [],
             "plannedTurns": [],
-            "platformType": "boghammer",
             "platformTypeId" : "a4",
             "status": {
               "state": "Landed"
@@ -445,7 +433,6 @@ export const forces: ForceData[] = [
             "turn": 5
           }
         ],
-        "platformType": "fishing-vessel",
         "platformTypeId" : "a1",
         "position": "830910fffffffff",
         "status": {
@@ -500,7 +487,6 @@ export const forces: ForceData[] = [
             "turn": 5
           }
         ],
-        "platformType": "fishing-vessel",
         "platformTypeId" : "a1",
         "position": "830765fffffffff",
         "status": {
@@ -523,7 +509,6 @@ export const forces: ForceData[] = [
         "name": "Missile-A",
         "perceptions": [],
         "plannedTurns": [],
-        "platformType": "coastal-radar-site",
         "platformTypeId" : "a12",
         "position": "830744fffffffff",
         "status": {
@@ -595,7 +580,6 @@ export const forces: ForceData[] = [
             "turn": 4
           }
         ],
-        "platformType": "merchant-vessel",
         "platformTypeId" : "a13",
         "position": "831b21fffffffff",
         "status": {
@@ -654,7 +638,6 @@ export const forces: ForceData[] = [
             "turn": 4
           }
         ],
-        "platformType": "merchant-vessel",
         "platformTypeId" : "a13",
         "position": "831b31fffffffff",
         "status": {
@@ -702,7 +685,6 @@ export const forces: ForceData[] = [
             "turn": 4
           }          
         ],
-        "platformType": "fishing-vessel",
         "platformTypeId" : "a1",
         "position": "831b2dfffffffff",
         "status": {
@@ -750,7 +732,6 @@ export const forces: ForceData[] = [
             "turn": 4
           }
         ],
-        "platformType": "fishing-vessel",
         "platformTypeId" : "a1",
         "position": "83064bfffffffff",
         "status": {
@@ -805,7 +786,6 @@ export const forces: ForceData[] = [
             "turn": 4
           }
         ],
-        "platformType": "fishing-vessel",
         "platformTypeId" : "a1",
         "position": "830761fffffffff",
         "status": {

--- a/packages/mocks/cmd-week.mock.ts
+++ b/packages/mocks/cmd-week.mock.ts
@@ -391,7 +391,6 @@ const game: Wargame = {
                         }
                       ],
                       "plannedTurns": [],
-                      "platformType": "Unmanned-Airborne-Vehicle",
                       "platformTypeId": "id-uav",
                       "status": {
                         "state": "Landed"
@@ -405,7 +404,6 @@ const game: Wargame = {
                       "name": "Dart 46",
                       "perceptions": [],
                       "plannedTurns": [],
-                      "platformType": "Unmanned-Airborne-Vehicle",
                       "platformTypeId": "id-uav",
                       "status": {
                         "state": "Landed"
@@ -422,7 +420,6 @@ const game: Wargame = {
                       "name": "Frigate A Perceived Name"
                     }
                   ],
-                  "platformType": "frigate",
                   "uniqid": "a0prbr6441"
                 },
                 {
@@ -431,7 +428,6 @@ const game: Wargame = {
                   "history": [],
                   "name": "MCM Delta",
                   "perceptions": [],
-                  "platformType": "MCMV",
                   "platformTypeId": "id-mcm",
                   "uniqid": "a0traa6790"
                 }
@@ -501,7 +497,6 @@ const game: Wargame = {
                   "turn": 5
                 }
               ],
-              "platformType": "task-group",
               "platformTypeId": "id-task-group",
               "position": "8318adfffffffff",
               "status": {
@@ -539,7 +534,6 @@ const game: Wargame = {
                     }
                   ],
                   "plannedTurns": [],
-                  "platformType": "helicopter",
                   "platformTypeId": "id-helo",
                   "status": {
                     "state": "Landed"
@@ -553,7 +547,6 @@ const game: Wargame = {
                   "name": "Dart 42",
                   "perceptions": [],
                   "plannedTurns": [],
-                  "platformType": "Unmanned-Airborne-Vehicle",
                   "platformTypeId": "id-uav",
                   "status": {
                     "state": "Landed"
@@ -592,7 +585,6 @@ const game: Wargame = {
                   "turn": 5
                 }
               ],
-              "platformType": "frigate",
               "platformTypeId": "id-frigate",
               "position": "8318a3fffffffff",
               "status": {
@@ -608,7 +600,6 @@ const game: Wargame = {
               "name": "MPA",
               "perceptions": [],
               "plannedTurns": [],
-              "platformType": "fixed-wing-aircraft",
               "platformTypeId": "id-fixed-wing",
               "position": "831976fffffffff",
               "status": {
@@ -661,7 +652,6 @@ const game: Wargame = {
                   "turn": 5
                 }
               ],
-              "platformType": "merchant-vessel",
               "platformTypeId": "id-merchant",
               "position": "83181cfffffffff",
               "status": {
@@ -733,7 +723,6 @@ const game: Wargame = {
                   "turn": 4
                 }
               ],
-              "platformType": "fishing-vessel",
               "platformTypeId": "id-fisher",
               "position": "830932fffffffff",
               "status": {
@@ -765,7 +754,6 @@ const game: Wargame = {
                   "name": "Bog Draft",
                   "perceptions": [],
                   "plannedTurns": [],
-                  "platformType": "boghammer",
                   "platformTypeId": "id-boghammer",
                   "status": {
                     "state": "Landed"
@@ -806,7 +794,6 @@ const game: Wargame = {
                   "turn": 5
                 }
               ],
-              "platformType": "fishing-vessel",
               "platformTypeId": "id-fisher",
               "position": "830910fffffffff",
               "status": {
@@ -863,7 +850,6 @@ const game: Wargame = {
                   "turn": 5
                 }
               ],
-              "platformType": "fishing-vessel",
               "platformTypeId": "id-fisher",
               "position": "830765fffffffff",
               "status": {
@@ -886,7 +872,6 @@ const game: Wargame = {
               "name": "Missile-A",
               "perceptions": [],
               "plannedTurns": [],
-              "platformType": "coastal-radar-site",
               "platformTypeId": "id-missile",
               "position": "830744fffffffff",
               "status": {
@@ -960,7 +945,6 @@ const game: Wargame = {
                   "turn": 4
                 }
               ],
-              "platformType": "merchant-vessel",
               "platformTypeId": "id-merchant",
               "position": "831b21fffffffff",
               "status": {
@@ -1021,7 +1005,6 @@ const game: Wargame = {
                   "turn": 4
                 }
               ],
-              "platformType": "merchant-vessel",
               "platformTypeId": "id-merchant",
               "position": "831b31fffffffff",
               "status": {
@@ -1071,7 +1054,6 @@ const game: Wargame = {
                   "turn": 4
                 }
               ],
-              "platformType": "fishing-vessel",
               "platformTypeId": "id-fisher",
               "position": "831b2dfffffffff",
               "status": {
@@ -1121,7 +1103,6 @@ const game: Wargame = {
                   "turn": 4
                 }
               ],
-              "platformType": "fishing-vessel",
               "platformTypeId": "id-fisher",
               "position": "83064bfffffffff",
               "status": {
@@ -1178,7 +1159,6 @@ const game: Wargame = {
                   "turn": 4
                 }
               ],
-              "platformType": "fishing-vessel",
               "platformTypeId": "id-fisher",
               "position": "830761fffffffff",
               "status": {

--- a/packages/mocks/forces.mock.ts
+++ b/packages/mocks/forces.mock.ts
@@ -72,7 +72,6 @@ export const forces: ForceData[] = [
                 force: 'Blue',
                 name: 'Frigate A Perceived Name'
               }],
-              platformType: 'frigate',
               platformTypeId : 'a3',
               hosting: [
                 {
@@ -88,7 +87,6 @@ export const forces: ForceData[] = [
                     typeId: 'a10'
                   }],
                       plannedTurns: [],
-                  platformType: 'Unmanned-Airborne-Vehicle',
                   platformTypeId : 'a10',
                   status: {
                     state: 'Landed'
@@ -103,7 +101,6 @@ export const forces: ForceData[] = [
                   name: 'Dart 46',
                   perceptions: [],
                   plannedTurns: [],
-                  platformType: 'Unmanned-Airborne-Vehicle',
                   platformTypeId : 'a10',
                   status: {
                     state: 'Landed'
@@ -124,7 +121,6 @@ export const forces: ForceData[] = [
               ],
               name: 'MCM Delta',
               perceptions: [],
-              platformType: 'MCMV',
               platformTypeId : 'a7',
               status: {
                 speedKts: 20,
@@ -164,7 +160,6 @@ export const forces: ForceData[] = [
             turn: 5
           }
         ],
-        platformType: 'task-group',
         platformTypeId : 'a11',
         position: 'P19',
         status: {
@@ -200,7 +195,6 @@ export const forces: ForceData[] = [
               typeId: 'a8'
             }],
             plannedTurns: [],
-            platformType: 'helicopter',
             platformTypeId : 'a8',
             status: {
               state: 'Landed'
@@ -215,7 +209,6 @@ export const forces: ForceData[] = [
             name: 'Dart 42',
             perceptions: [],
             plannedTurns: [],
-            platformType: 'Unmanned-Airborne-Vehicle',
             platformTypeId : 'a10',
             status: {
               state: 'Landed'
@@ -253,7 +246,6 @@ export const forces: ForceData[] = [
             turn: 5
           }
         ],
-        platformType: 'frigate',
         platformTypeId : 'a3',
         position: 'P21',
         status: {
@@ -270,7 +262,6 @@ export const forces: ForceData[] = [
         name: 'MPA',
         perceptions: [],
         plannedTurns: [],
-        platformType: 'fixed-wing-aircraft',
         platformTypeId : 'a9',
         position: 'C17',
         status: {
@@ -331,7 +322,6 @@ export const forces: ForceData[] = [
             turn: 6
           }
         ],
-        platformType: 'merchant-vessel',
         position: 'O21',
         platformTypeId : 'a13',
         status: {
@@ -427,7 +417,6 @@ export const forces: ForceData[] = [
             turn: 5
           }
         ],
-        platformType: 'fishing-vessel',
         platformTypeId : 'a1',
         position: 'M04',
         status: {
@@ -459,7 +448,6 @@ export const forces: ForceData[] = [
             name: 'Bog Draft',
             perceptions: [],
             plannedTurns: [],
-            platformType: 'boghammer',
             platformTypeId : 'a4',
             status: {
               speedKts: 10,
@@ -519,7 +507,6 @@ export const forces: ForceData[] = [
             turn: 7
           }
         ],
-        platformType: 'fishing-vessel',
         platformTypeId : 'a1',
         position: 'M10',
         status: {
@@ -575,7 +562,6 @@ export const forces: ForceData[] = [
             turn: 5
           }
         ],
-        platformType: 'fishing-vessel',
         platformTypeId : 'a1',
         position: 'P17',
         status: {
@@ -600,7 +586,6 @@ export const forces: ForceData[] = [
         name: 'Missile-A',
         perceptions: [],
         plannedTurns: [],
-        platformType: 'coastal-radar-site',
         platformTypeId : 'a12',
         position: 'Q12',
         status: {
@@ -753,7 +738,6 @@ export const forces: ForceData[] = [
             turn: 11
           }
         ],
-        platformType: 'merchant-vessel',
         platformTypeId : 'a13',
         position: 'H03',
         status: {
@@ -908,7 +892,6 @@ export const forces: ForceData[] = [
             turn: 11
           }
         ],
-        platformType: 'merchant-vessel',
         platformTypeId : 'a13',
         position: 'C00',
         status: {
@@ -1022,7 +1005,6 @@ export const forces: ForceData[] = [
             turn: 11
           }
         ],
-        platformType: 'fishing-vessel',
         platformTypeId : 'a1',
         position: 'K03',
         status: {
@@ -1137,7 +1119,6 @@ export const forces: ForceData[] = [
             turn: 12
           }
         ],
-        platformType: 'fishing-vessel',
         platformTypeId : 'a1',
         position: 'L09',
         status: {
@@ -1260,7 +1241,6 @@ export const forces: ForceData[] = [
             turn: 11
           }
         ],
-        platformType: 'fishing-vessel',
         platformTypeId : 'a1',
         position: 'N11',
         status: {

--- a/packages/mocks/p9.mock.ts
+++ b/packages/mocks/p9.mock.ts
@@ -171,7 +171,6 @@ const game: Wargame = {
                           typeId: 'id-uav'
                         }
                       ],
-                      platformType: 'Unmanned-Airborne-Vehicle',
                       platformTypeId: 'id-uav',
                       status: {
                         state: 'Landed'
@@ -183,7 +182,6 @@ const game: Wargame = {
                       contactId: 'C932',
                       name: 'Dart 46',
                       perceptions: [],
-                      platformType: 'Unmanned-Airborne-Vehicle',
                       platformTypeId: 'id-uav',
                       status: {
                         state: 'Landed'
@@ -200,7 +198,6 @@ const game: Wargame = {
                       name: 'Frigate A Perceived Name'
                     }
                   ],
-                  platformType: 'frigate',
                   uniqid: 'a0prbr6441'
                 },
                 {
@@ -208,7 +205,6 @@ const game: Wargame = {
                   contactId: 'C653',
                   name: 'MCM Delta',
                   perceptions: [],
-                  platformType: 'MCMV',
                   platformTypeId: 'id-mcm',
                   uniqid: 'a0traa6790'
                 }
@@ -224,7 +220,6 @@ const game: Wargame = {
                   typeId: 'id-task-group'
                 }
               ],
-              platformType: 'task-group',
               platformTypeId: 'id-task-group',
               position: '8318adfffffffff',
               status: {
@@ -250,7 +245,6 @@ const game: Wargame = {
                     }
                   ],
                   plannedTurns: [],
-                  platformType: 'helicopter',
                   platformTypeId: 'id-helo',
                   status: {
                     state: 'Landed'
@@ -264,7 +258,6 @@ const game: Wargame = {
                   name: 'Dart 42',
                   perceptions: [],
                   plannedTurns: [],
-                  platformType: 'Unmanned-Airborne-Vehicle',
                   platformTypeId: 'id-uav',
                   status: {
                     state: 'Landed'
@@ -281,7 +274,6 @@ const game: Wargame = {
                   typeId: 'id-frigate'
                 }
               ],
-              platformType: 'frigate',
               platformTypeId: 'id-frigate',
               position: '8318a3fffffffff',
               status: {
@@ -295,7 +287,6 @@ const game: Wargame = {
               contactId: 'C072',
               name: 'MPA',
               perceptions: [],
-              platformType: 'fixed-wing-aircraft',
               platformTypeId: 'id-fixed-wing',
               position: '831976fffffffff',
               status: {
@@ -314,7 +305,6 @@ const game: Wargame = {
                   typeId: ''
                 }
               ],
-              platformType: 'merchant-vessel',
               platformTypeId: 'id-merchant',
               position: '83181cfffffffff',
               uniqid: 'a0pra00003'
@@ -348,7 +338,6 @@ const game: Wargame = {
                   by: 'Blue'
                 }
               ],
-              platformType: 'fishing-vessel',
               platformTypeId: 'id-fisher',
               position: '830932fffffffff',
               uniqid: 'a0pra000100'
@@ -362,7 +351,6 @@ const game: Wargame = {
                   contactId: 'C158',
                   name: 'Bog Draft',
                   perceptions: [],
-                  platformType: 'boghammer',
                   platformTypeId: 'id-boghammer',
                   status: {
                     state: 'Landed'
@@ -379,7 +367,6 @@ const game: Wargame = {
                   typeId: 'id-fishing'
                 }
               ],
-              platformType: 'fishing-vessel',
               platformTypeId: 'id-fisher',
               position: '830910fffffffff',
               uniqid: 'a0pra000101'
@@ -389,7 +376,6 @@ const game: Wargame = {
               contactId: 'C008',
               name: 'Dhow-C',
               perceptions: [],
-              platformType: 'fishing-vessel',
               platformTypeId: 'id-fisher',
               position: '830765fffffffff',
               uniqid: 'a0pra000102'
@@ -399,7 +385,6 @@ const game: Wargame = {
               contactId: 'C076',
               name: 'Missile-A',
               perceptions: [],
-              platformType: 'coastal-radar-site',
               platformTypeId: 'id-missile',
               position: '830744fffffffff',
               uniqid: 'a0pra000103'
@@ -436,7 +421,6 @@ const game: Wargame = {
                   typeId: 'id-merchant'
                 }
               ],
-              platformType: 'merchant-vessel',
               platformTypeId: 'id-merchant',
               position: '831b21fffffffff',
               uniqid: 'a0pra000200'
@@ -459,7 +443,6 @@ const game: Wargame = {
                   typeId: 'id-merchant'
                 }
               ],
-              platformType: 'merchant-vessel',
               platformTypeId: 'id-merchant',
               position: '831b31fffffffff',
               status: {
@@ -479,7 +462,6 @@ const game: Wargame = {
                   typeId: 'id-merchant'
                 }
               ],
-              platformType: 'fishing-vessel',
               platformTypeId: 'id-fisher',
               uniqid: 'a0pra000202'
             },
@@ -494,7 +476,6 @@ const game: Wargame = {
                   typeId: 'id-merchant'
                 }
               ],
-              platformType: 'fishing-vessel',
               platformTypeId: 'id-fisher',
               position: '83064bfffffffff',
               status: {
@@ -521,7 +502,6 @@ const game: Wargame = {
                   typeId: 'id-merchant'
                 }
               ],
-              platformType: 'fishing-vessel',
               platformTypeId: 'id-fisher',
               uniqid: 'a0pra000204'
             }

--- a/packages/mocks/p9.mock.ts
+++ b/packages/mocks/p9.mock.ts
@@ -168,7 +168,7 @@ const game: Wargame = {
                           by: 'Red',
                           force: 'Blue',
                           name: 'Unknown UAV',
-                          typeId: 'Unmanned-Airborne-Vehicle'
+                          typeId: 'id-uav'
                         }
                       ],
                       platformType: 'Unmanned-Airborne-Vehicle',
@@ -221,7 +221,7 @@ const game: Wargame = {
                   by: 'Red',
                   force: 'Blue',
                   name: 'BRIT',
-                  typeId: 'task-group'
+                  typeId: 'id-task-group'
                 }
               ],
               platformType: 'task-group',
@@ -246,7 +246,7 @@ const game: Wargame = {
                     {
                       by: 'Red',
                       force: 'Blue',
-                      typeId: 'helicopter'
+                      typeId: 'id-helo'
                     }
                   ],
                   plannedTurns: [],
@@ -278,7 +278,7 @@ const game: Wargame = {
                   by: 'Red',
                   force: 'Blue',
                   name: 'Frigate Perceived Name',
-                  typeId: 'frigate'
+                  typeId: 'id-frigate'
                 }
               ],
               platformType: 'frigate',
@@ -376,7 +376,7 @@ const game: Wargame = {
                   by: 'Blue',
                   force: 'Green',
                   name: 'SHU’AI',
-                  typeId: 'fishing-vessel'
+                  typeId: 'id-fishing'
                 }
               ],
               platformType: 'fishing-vessel',
@@ -433,7 +433,7 @@ const game: Wargame = {
                   by: 'Blue',
                   force: 'Green',
                   name: 'OSAKA',
-                  typeId: 'merchant-vessel'
+                  typeId: 'id-merchant'
                 }
               ],
               platformType: 'merchant-vessel',
@@ -450,13 +450,13 @@ const game: Wargame = {
                   by: 'Blue',
                   force: 'Green',
                   name: 'ARUNA 12',
-                  typeId: 'merchant-vessel'
+                  typeId: 'id-merchant'
                 },
                 {
                   by: 'Red',
                   force: 'Green',
                   name: 'BARLAY',
-                  typeId: 'merchant-vessel'
+                  typeId: 'id-merchant'
                 }
               ],
               platformType: 'merchant-vessel',
@@ -476,7 +476,7 @@ const game: Wargame = {
                   by: 'Blue',
                   force: 'Green',
                   name: 'JALIBUT',
-                  typeId: 'merchant-vessel'
+                  typeId: 'id-merchant'
                 }
               ],
               platformType: 'fishing-vessel',
@@ -491,7 +491,7 @@ const game: Wargame = {
                 {
                   by: 'Blue',
                   force: 'Green',
-                  typeId: 'merchant-vessel'
+                  typeId: 'id-merchant'
                 }
               ],
               platformType: 'fishing-vessel',
@@ -512,13 +512,13 @@ const game: Wargame = {
                   by: 'Blue',
                   force: 'Green',
                   name: 'BOUM 3',
-                  typeId: 'merchant-vessel'
+                  typeId: 'id-merchant'
                 },
                 {
                   by: 'Red',
                   force: 'Green',
                   name: 'BOUM 3',
-                  typeId: 'merchant-vessel'
+                  typeId: 'id-merchant'
                 }
               ],
               platformType: 'fishing-vessel',

--- a/packages/mocks/p9.mock.ts
+++ b/packages/mocks/p9.mock.ts
@@ -1,1102 +1,978 @@
-import { Wargame } from "@serge/custom-types";
+import { Wargame } from '@serge/custom-types';
 
 const game: Wargame = {
-  "adjudicationStartTime": "2021-08-10T16:12:25+01:00",
-  "wargameList": [],
-  "data": {
-    "channels": {
-      "channels": [
+  adjudicationStartTime: '2021-08-10T16:12:25+01:00',
+  wargameList: [],
+  data: {
+    channels: {
+      channels: [
         {
-          "name": "Planning",
-          "channelType": "ChannelPlanning",
-          "participants": [
+          name: 'Planning',
+          channelType: 'ChannelPlanning',
+          participants: [
             {
-              "force": "CTF A",
-              "forceUniqid": "Blue",
-              "pType": "ParticipantPlanning",
-              "roles": [],
-              "subscriptionId": "hukqr",
-              "templates": [{
-                  "_id": "k16eedkm",
-                  "title": "COA"
-              }]
-            },
-            {
-              "force": "Red",
-              "forceUniqid": "Red",
-              "pType": "ParticipantPlanning",
-              "roles": [],
-              "subscriptionId": "hukqr",
-              "templates": [
+              force: 'CTF A',
+              forceUniqid: 'Blue',
+              pType: 'ParticipantPlanning',
+              roles: [],
+              subscriptionId: 'hukqr',
+              templates: [
                 {
-                  "_id": "k16eedkm",
-                  "title": "COA"
+                  _id: 'k16eedkm',
+                  title: 'COA'
                 }
               ]
             },
             {
-              "force": "White",
-              "pType": "ParticipantPlanning",
-              "forceUniqid": "umpire",
-              "roles": [
-                "rkrlw6f5f"
-              ],
-              "subscriptionId": "r4yp",
-              "templates": []
-            }
-          ],
-          "uniqid": "channel-planning-a"
-        },
-        {
-          "name": "Red",
-          "channelType": "ChannelChat",
-          "participants": [
-            {
-              "force": "CTF Y",
-              "forceUniqid": "Red",
-              "roles": [],
-              "subscriptionId": "7bayi",
-              "pType": "ParticipantChat"
-            },
-            {
-              "force": "White",
-              "forceUniqid": "umpire",
-              "roles": [
-                "rkrlw6f5f"
-              ],
-              "subscriptionId": "h2my2k",
-              "pType": "ParticipantChat"
-            }
-          ],
-          "uniqid": "channel-koirfxsx"
-        },
-        {
-          "name": "Blue RFI",
-          "channelType": "ChannelCustom",
-          "participants": [
-            {
-              "pType": "ParticipantCustom",
-              "force": "CTF B",
-              "forceUniqid": "Blue",
-              "roles": [],
-              "subscriptionId": "etkkn",
-              "templates": [
+              force: 'Red',
+              forceUniqid: 'Red',
+              pType: 'ParticipantPlanning',
+              roles: [],
+              subscriptionId: 'hukqr',
+              templates: [
                 {
-                  "_id": "2021-08-23T07:58:43.425Z",
-                  "title": "RFI"
+                  _id: 'k16eedkm',
+                  title: 'COA'
                 }
               ]
             },
             {
-              "force": "White",
-              "pType": "ParticipantCustom",
-              "forceUniqid": "umpire",
-              "roles": [
-                "rkrlw6f5f"
-              ],
-              "subscriptionId": "qhnqr",
-              "templates": []
+              force: 'White',
+              pType: 'ParticipantPlanning',
+              forceUniqid: 'umpire',
+              roles: ['rkrlw6f5f'],
+              subscriptionId: 'r4yp',
+              templates: []
             }
           ],
-          "uniqid": "channel-koirh7ok"
+          uniqid: 'channel-planning-a'
         },
         {
-          "name": "Red RFI",
-          "channelType": "ChannelCustom",
-          "participants": [
+          name: 'Red',
+          channelType: 'ChannelChat',
+          participants: [
             {
-              "force": "White",
-              "pType": "ParticipantCustom",
-              "forceUniqid": "umpire",
-              "roles": [
-                "rks5zfzd5"
-              ],
-              "subscriptionId": "lity",
-              "templates": []
+              force: 'CTF Y',
+              forceUniqid: 'Red',
+              roles: [],
+              subscriptionId: '7bayi',
+              pType: 'ParticipantChat'
             },
             {
-              "force": "CTF Y",
-              "pType": "ParticipantCustom",
-              "forceUniqid": "Red",
-              "roles": [],
-              "subscriptionId": "3b3ww",
-              "templates": [
+              force: 'White',
+              forceUniqid: 'umpire',
+              roles: ['rkrlw6f5f'],
+              subscriptionId: 'h2my2k',
+              pType: 'ParticipantChat'
+            }
+          ],
+          uniqid: 'channel-koirfxsx'
+        },
+        {
+          name: 'Blue RFI',
+          channelType: 'ChannelCustom',
+          participants: [
+            {
+              pType: 'ParticipantCustom',
+              force: 'CTF B',
+              forceUniqid: 'Blue',
+              roles: [],
+              subscriptionId: 'etkkn',
+              templates: [
                 {
-                  "_id": "2021-08-23T07:58:43.425Z",
-                  "title": "RFI"
+                  _id: '2021-08-23T07:58:43.425Z',
+                  title: 'RFI'
+                }
+              ]
+            },
+            {
+              force: 'White',
+              pType: 'ParticipantCustom',
+              forceUniqid: 'umpire',
+              roles: ['rkrlw6f5f'],
+              subscriptionId: 'qhnqr',
+              templates: []
+            }
+          ],
+          uniqid: 'channel-koirh7ok'
+        },
+        {
+          name: 'Red RFI',
+          channelType: 'ChannelCustom',
+          participants: [
+            {
+              force: 'White',
+              pType: 'ParticipantCustom',
+              forceUniqid: 'umpire',
+              roles: ['rks5zfzd5'],
+              subscriptionId: 'lity',
+              templates: []
+            },
+            {
+              force: 'CTF Y',
+              pType: 'ParticipantCustom',
+              forceUniqid: 'Red',
+              roles: [],
+              subscriptionId: '3b3ww',
+              templates: [
+                {
+                  _id: '2021-08-23T07:58:43.425Z',
+                  title: 'RFI'
                 }
               ]
             }
           ],
-          "uniqid": "channel-koirji8u"
-        }       
+          uniqid: 'channel-koirji8u'
+        }
       ],
-      "dirty": false,
-      "name": "Channels",
-      "selectedChannel": ""
+      dirty: false,
+      name: 'Channels',
+      selectedChannel: ''
     },
-    "forces": {
-      "dirty": false,
-      "forces": [
+    forces: {
+      dirty: false,
+      forces: [
         {
-          "color": "#FCFBEE",
-          "dirty": false,
-          "iconURL": "default_img/umpireDefault.png",
-          "name": "White",
-          "overview": "Umpire force.",
-          "roles": [
+          color: '#FCFBEE',
+          dirty: false,
+          iconURL: 'default_img/umpireDefault.png',
+          name: 'White',
+          overview: 'Umpire force.',
+          roles: [
             {
-              "isGameControl": true,
-              "isInsightViewer": true,
-              "isObserver": true,
-              "name": "Game Control",
-              "roleId": "rkrlw6f5f"
+              isGameControl: true,
+              isInsightViewer: true,
+              isObserver: true,
+              name: 'Game Control',
+              roleId: 'rkrlw6f5f'
             }
           ],
-          "umpire": true,
-          "uniqid": "umpire"
+          umpire: true,
+          uniqid: 'umpire'
         },
         {
-          "assets": [
+          assets: [
             {
-              "comprising": [
+              comprising: [
                 {
-                  "condition": "Full capability",
-                  "contactId": "C964",
-                  "history": [],
-                  "hosting": [
+                  condition: 'Full capability',
+                  contactId: 'C964',
+                  history: [],
+                  hosting: [
                     {
-                      "condition": "Full capability",
-                      "contactId": "C721",
-                      "name": "Dart 45",
-                      "perceptions": [
+                      condition: 'Full capability',
+                      contactId: 'C721',
+                      name: 'Dart 45',
+                      perceptions: [
                         {
-                          "by": "Red",
-                          "force": "Blue",
-                          "name": "Unknown UAV",
-                          "type": "Unmanned-Airborne-Vehicle"
+                          by: 'Red',
+                          force: 'Blue',
+                          name: 'Unknown UAV',
+                          typeId: 'Unmanned-Airborne-Vehicle'
                         }
                       ],
-                      "platformType": "Unmanned-Airborne-Vehicle",
-                      "platformTypeId": "id-uav",
-                      "status": {
-                        "state": "Landed"
+                      platformType: 'Unmanned-Airborne-Vehicle',
+                      platformTypeId: 'id-uav',
+                      status: {
+                        state: 'Landed'
                       },
-                      "uniqid": "a0pra43302"
+                      uniqid: 'a0pra43302'
                     },
                     {
-                      "condition": "Full capability",
-                      "contactId": "C932",
-                      "name": "Dart 46",
-                      "perceptions": [],
-                      "platformType": "Unmanned-Airborne-Vehicle",
-                      "platformTypeId": "id-uav",
-                      "status": {
-                        "state": "Landed"
+                      condition: 'Full capability',
+                      contactId: 'C932',
+                      name: 'Dart 46',
+                      perceptions: [],
+                      platformType: 'Unmanned-Airborne-Vehicle',
+                      platformTypeId: 'id-uav',
+                      status: {
+                        state: 'Landed'
                       },
-                      "uniqid": "a0pra17943"
+                      uniqid: 'a0pra17943'
                     }
                   ],
-                  "name": "Frigate A",
-                  "platformTypeId": "id-frigate",
-                  "perceptions": [
+                  name: 'Frigate A',
+                  platformTypeId: 'id-frigate',
+                  perceptions: [
                     {
-                      "by": "Red",
-                      "force": "Blue",
-                      "name": "Frigate A Perceived Name"
+                      by: 'Red',
+                      force: 'Blue',
+                      name: 'Frigate A Perceived Name'
                     }
                   ],
-                  "platformType": "frigate",
-                  "uniqid": "a0prbr6441"
+                  platformType: 'frigate',
+                  uniqid: 'a0prbr6441'
                 },
                 {
-                  "condition": "Full capability",
-                  "contactId": "C653",
-                  "name": "MCM Delta",
-                  "perceptions": [],
-                  "platformType": "MCMV",
-                  "platformTypeId": "id-mcm",
-                  "uniqid": "a0traa6790"
+                  condition: 'Full capability',
+                  contactId: 'C653',
+                  name: 'MCM Delta',
+                  perceptions: [],
+                  platformType: 'MCMV',
+                  platformTypeId: 'id-mcm',
+                  uniqid: 'a0traa6790'
                 }
               ],
-              "condition": "Full capability",
-              "contactId": "C713",
-              "name": "CTF 511",
-              "perceptions": [
+              condition: 'Full capability',
+              contactId: 'C713',
+              name: 'CTF 511',
+              perceptions: [
                 {
-                  "by": "Red",
-                  "force": "Blue",
-                  "name": "BRIT",
-                  "type": "task-group"
+                  by: 'Red',
+                  force: 'Blue',
+                  name: 'BRIT',
+                  typeId: 'task-group'
                 }
               ],
-              "platformType": "task-group",
-              "platformTypeId": "id-task-group",
-              "position": "8318adfffffffff",
-              "status": {
-                "speedKts": 10,
-                "state": "Transiting"
+              platformType: 'task-group',
+              platformTypeId: 'id-task-group',
+              position: '8318adfffffffff',
+              status: {
+                speedKts: 10,
+                state: 'Transiting'
               },
-              "uniqid": "a0pra5431"
+              uniqid: 'a0pra5431'
             },
             {
-              "condition": "Full capability",
-              "contactId": "C043",
-              "hosting": [
+              condition: 'Full capability',
+              contactId: 'C043',
+              hosting: [
                 {
-                  "condition": "Full capability",
-                  "contactId": "C572",
-                  "history": [],
-                  "name": "Merlin",
-                  "perceptions": [
+                  condition: 'Full capability',
+                  contactId: 'C572',
+                  history: [],
+                  name: 'Merlin',
+                  perceptions: [
                     {
-                      "by": "Red",
-                      "force": "Blue",
-                      "type": "helicopter"
+                      by: 'Red',
+                      force: 'Blue',
+                      typeId: 'helicopter'
                     }
                   ],
-                  "plannedTurns": [],
-                  "platformType": "helicopter",
-                  "platformTypeId": "id-helo",
-                  "status": {
-                    "state": "Landed"
+                  plannedTurns: [],
+                  platformType: 'helicopter',
+                  platformTypeId: 'id-helo',
+                  status: {
+                    state: 'Landed'
                   },
-                  "uniqid": "a0pra11002"
+                  uniqid: 'a0pra11002'
                 },
                 {
-                  "condition": "Full capability",
-                  "contactId": "C591",
-                  "history": [],
-                  "name": "Dart 42",
-                  "perceptions": [],
-                  "plannedTurns": [],
-                  "platformType": "Unmanned-Airborne-Vehicle",
-                  "platformTypeId": "id-uav",
-                  "status": {
-                    "state": "Landed"
+                  condition: 'Full capability',
+                  contactId: 'C591',
+                  history: [],
+                  name: 'Dart 42',
+                  perceptions: [],
+                  plannedTurns: [],
+                  platformType: 'Unmanned-Airborne-Vehicle',
+                  platformTypeId: 'id-uav',
+                  status: {
+                    state: 'Landed'
                   },
-                  "uniqid": "a0pra18702"
+                  uniqid: 'a0pra18702'
                 }
               ],
-              "name": "Frigate",
-              "perceptions": [
+              name: 'Frigate',
+              perceptions: [
                 {
-                  "by": "Red",
-                  "force": "Blue",
-                  "name": "Frigate Perceived Name",
-                  "type": "frigate"
+                  by: 'Red',
+                  force: 'Blue',
+                  name: 'Frigate Perceived Name',
+                  typeId: 'frigate'
                 }
               ],
-              "platformType": "frigate",
-              "platformTypeId": "id-frigate",
-              "position": "8318a3fffffffff",
-              "status": {
-                "speedKts": 20,
-                "state": "Transiting"
+              platformType: 'frigate',
+              platformTypeId: 'id-frigate',
+              position: '8318a3fffffffff',
+              status: {
+                speedKts: 20,
+                state: 'Transiting'
               },
-              "uniqid": "a0pra00001"
+              uniqid: 'a0pra00001'
             },
             {
-              "condition": "Full capability",
-              "contactId": "C072",
-              "name": "MPA",
-              "perceptions": [],
-              "platformType": "fixed-wing-aircraft",
-              "platformTypeId": "id-fixed-wing",
-              "position": "831976fffffffff",
-              "status": {
-                "state": "Landed"
+              condition: 'Full capability',
+              contactId: 'C072',
+              name: 'MPA',
+              perceptions: [],
+              platformType: 'fixed-wing-aircraft',
+              platformTypeId: 'id-fixed-wing',
+              position: '831976fffffffff',
+              status: {
+                state: 'Landed'
               },
-              "uniqid": "a0pra00002"
+              uniqid: 'a0pra00002'
             },
             {
-              "condition": "Full capability",
-              "contactId": "C012",
-              "name": "Tanker",
-              "perceptions": [
+              condition: 'Full capability',
+              contactId: 'C012',
+              name: 'Tanker',
+              perceptions: [
                 {
-                  "by": "Red",
-                  "force": "Blue",
-                  "type": ""
+                  by: 'Red',
+                  force: 'Blue',
+                  typeId: ''
                 }
               ],
-              "platformType": "merchant-vessel",
-              "platformTypeId": "id-merchant",
-              "position": "83181cfffffffff",
-              "uniqid": "a0pra00003"
+              platformType: 'merchant-vessel',
+              platformTypeId: 'id-merchant',
+              position: '83181cfffffffff',
+              uniqid: 'a0pra00003'
             }
           ],
-          "color": "#00F",
-          "dirty": false,
-          "iconURL": "default_img/umpireDefault.png",
-          "name": "Blue",
-          "overview": "Blue force.",
-          "roles": [
+          color: '#00F',
+          dirty: false,
+          iconURL: 'default_img/umpireDefault.png',
+          name: 'Blue',
+          overview: 'Blue force.',
+          roles: [
             {
-              "isGameControl": false,
-              "isInsightViewer": false,
-              "isObserver": false,
-              "name": "CO",
-              "roleId": "rk116f5e"
+              isGameControl: false,
+              isInsightViewer: false,
+              isObserver: false,
+              name: 'CO',
+              roleId: 'rk116f5e'
             }
           ],
-          "umpire": false,
-          "uniqid": "Blue"
+          umpire: false,
+          uniqid: 'Blue'
         },
         {
-          "assets": [
+          assets: [
             {
-              "condition": "Full capability",
-              "contactId": "C065",
-              "name": "Dhow-A",
-              "perceptions": [
+              condition: 'Full capability',
+              contactId: 'C065',
+              name: 'Dhow-A',
+              perceptions: [
                 {
-                  "by": "Blue"
+                  by: 'Blue'
                 }
               ],
-              "platformType": "fishing-vessel",
-              "platformTypeId": "id-fisher",
-              "position": "830932fffffffff",
-              "uniqid": "a0pra000100"
+              platformType: 'fishing-vessel',
+              platformTypeId: 'id-fisher',
+              position: '830932fffffffff',
+              uniqid: 'a0pra000100'
             },
             {
-              "condition": "Full capability",
-              "contactId": "C105",
-              "hosting": [
+              condition: 'Full capability',
+              contactId: 'C105',
+              hosting: [
                 {
-                  "condition": "Full capability",
-                  "contactId": "C158",
-                  "name": "Bog Draft",
-                  "perceptions": [],
-                  "platformType": "boghammer",
-                  "platformTypeId": "id-boghammer",
-                  "status": {
-                    "state": "Landed"
+                  condition: 'Full capability',
+                  contactId: 'C158',
+                  name: 'Bog Draft',
+                  perceptions: [],
+                  platformType: 'boghammer',
+                  platformTypeId: 'id-boghammer',
+                  status: {
+                    state: 'Landed'
                   },
-                  "uniqid": "a0pra153102"
+                  uniqid: 'a0pra153102'
                 }
               ],
-              "name": "Dhow-B",
-              "perceptions": [
+              name: 'Dhow-B',
+              perceptions: [
                 {
-                  "by": "Blue",
-                  "force": "Green",
-                  "name": "SHU’AI",
-                  "type": "fishing-vessel"
+                  by: 'Blue',
+                  force: 'Green',
+                  name: 'SHU’AI',
+                  typeId: 'fishing-vessel'
                 }
               ],
-              "platformType": "fishing-vessel",
-              "platformTypeId": "id-fisher",
-              "position": "830910fffffffff",
-              "uniqid": "a0pra000101"
+              platformType: 'fishing-vessel',
+              platformTypeId: 'id-fisher',
+              position: '830910fffffffff',
+              uniqid: 'a0pra000101'
             },
             {
-              "condition": "Full capability",
-              "contactId": "C008",
-              "name": "Dhow-C",
-              "perceptions": [],
-              "platformType": "fishing-vessel",
-              "platformTypeId": "id-fisher",
-              "position": "830765fffffffff",
-              "uniqid": "a0pra000102"
+              condition: 'Full capability',
+              contactId: 'C008',
+              name: 'Dhow-C',
+              perceptions: [],
+              platformType: 'fishing-vessel',
+              platformTypeId: 'id-fisher',
+              position: '830765fffffffff',
+              uniqid: 'a0pra000102'
             },
             {
-              "condition": "Full capability",
-              "contactId": "C076",
-              "name": "Missile-A",
-              "perceptions": [],
-              "platformType": "coastal-radar-site",
-              "platformTypeId": "id-missile",
-              "position": "830744fffffffff",
-              "uniqid": "a0pra000103"
+              condition: 'Full capability',
+              contactId: 'C076',
+              name: 'Missile-A',
+              perceptions: [],
+              platformType: 'coastal-radar-site',
+              platformTypeId: 'id-missile',
+              position: '830744fffffffff',
+              uniqid: 'a0pra000103'
             }
           ],
-          "color": "#F00",
-          "dirty": false,
-          "iconURL": "default_img/umpireDefault.png",
-          "name": "Red",
-          "overview": "Red force.",
-          "roles": [
+          color: '#F00',
+          dirty: false,
+          iconURL: 'default_img/umpireDefault.png',
+          name: 'Red',
+          overview: 'Red force.',
+          roles: [
             {
-              "isGameControl": false,
-              "isInsightViewer": false,
-              "isObserver": false,
-              "name": "CO",
-              "roleId": "rkr226f5e"
+              isGameControl: false,
+              isInsightViewer: false,
+              isObserver: false,
+              name: 'CO',
+              roleId: 'rkr226f5e'
             }
           ],
-          "umpire": false,
-          "uniqid": "Red"
+          umpire: false,
+          uniqid: 'Red'
         },
         {
-          "assets": [
+          assets: [
             {
-              "condition": "Full capability",
-              "contactId": "C015",
-              "name": "Tanker-1",
-              "perceptions": [
+              condition: 'Full capability',
+              contactId: 'C015',
+              name: 'Tanker-1',
+              perceptions: [
                 {
-                  "by": "Blue",
-                  "force": "Green",
-                  "name": "OSAKA",
-                  "type": "merchant-vessel"
+                  by: 'Blue',
+                  force: 'Green',
+                  name: 'OSAKA',
+                  typeId: 'merchant-vessel'
                 }
               ],
-              "platformType": "merchant-vessel",
-              "platformTypeId": "id-merchant",
-              "position": "831b21fffffffff",
-              "uniqid": "a0pra000200"
+              platformType: 'merchant-vessel',
+              platformTypeId: 'id-merchant',
+              position: '831b21fffffffff',
+              uniqid: 'a0pra000200'
             },
             {
-              "condition": "Full capability",
-              "contactId": "C081",
-              "name": "Tanker-2",
-              "perceptions": [
+              condition: 'Full capability',
+              contactId: 'C081',
+              name: 'Tanker-2',
+              perceptions: [
                 {
-                  "by": "Blue",
-                  "force": "Green",
-                  "name": "ARUNA 12",
-                  "type": "merchant-vessel"
+                  by: 'Blue',
+                  force: 'Green',
+                  name: 'ARUNA 12',
+                  typeId: 'merchant-vessel'
                 },
                 {
-                  "by": "Red",
-                  "force": "Green",
-                  "name": "BARLAY",
-                  "type": "merchant-vessel"
+                  by: 'Red',
+                  force: 'Green',
+                  name: 'BARLAY',
+                  typeId: 'merchant-vessel'
                 }
               ],
-              "platformType": "merchant-vessel",
-              "platformTypeId": "id-merchant",
-              "position": "831b31fffffffff",
-              "status": {
-                "state": "Moored"
+              platformType: 'merchant-vessel',
+              platformTypeId: 'id-merchant',
+              position: '831b31fffffffff',
+              status: {
+                state: 'Moored'
               },
-              "uniqid": "a0pra000201"
+              uniqid: 'a0pra000201'
             },
             {
-              "condition": "Full capability",
-              "contactId": "C116",
-              "name": "Fisher-A",
-              "perceptions": [
+              condition: 'Full capability',
+              contactId: 'C116',
+              name: 'Fisher-A',
+              perceptions: [
                 {
-                  "by": "Blue",
-                  "force": "Green",
-                  "name": "JALIBUT",
-                  "type": "merchant-vessel"
+                  by: 'Blue',
+                  force: 'Green',
+                  name: 'JALIBUT',
+                  typeId: 'merchant-vessel'
                 }
               ],
-              "platformType": "fishing-vessel",
-              "platformTypeId": "id-fisher",
-              "uniqid": "a0pra000202"
+              platformType: 'fishing-vessel',
+              platformTypeId: 'id-fisher',
+              uniqid: 'a0pra000202'
             },
             {
-              "condition": "Full capability",
-              "contactId": "C026",
-              "name": "Fisher-B",
-              "perceptions": [
+              condition: 'Full capability',
+              contactId: 'C026',
+              name: 'Fisher-B',
+              perceptions: [
                 {
-                  "by": "Blue",
-                  "force": "Green",
-                  "type": "merchant-vessel"
+                  by: 'Blue',
+                  force: 'Green',
+                  typeId: 'merchant-vessel'
                 }
               ],
-              "platformType": "fishing-vessel",
-              "platformTypeId": "id-fisher",
-              "position": "83064bfffffffff",
-              "status": {
-                "speedKts": 10,
-                "state": "Transiting"
+              platformType: 'fishing-vessel',
+              platformTypeId: 'id-fisher',
+              position: '83064bfffffffff',
+              status: {
+                speedKts: 10,
+                state: 'Transiting'
               },
-              "uniqid": "a0pra000203"
+              uniqid: 'a0pra000203'
             },
             {
-              "condition": "Full capability",
-              "contactId": "C115",
-              "name": "Fisher-C",
-              "perceptions": [
+              condition: 'Full capability',
+              contactId: 'C115',
+              name: 'Fisher-C',
+              perceptions: [
                 {
-                  "by": "Blue",
-                  "force": "Green",
-                  "name": "BOUM 3",
-                  "type": "merchant-vessel"
+                  by: 'Blue',
+                  force: 'Green',
+                  name: 'BOUM 3',
+                  typeId: 'merchant-vessel'
                 },
                 {
-                  "by": "Red",
-                  "force": "Green",
-                  "name": "BOUM 3",
-                  "type": "merchant-vessel"
+                  by: 'Red',
+                  force: 'Green',
+                  name: 'BOUM 3',
+                  typeId: 'merchant-vessel'
                 }
               ],
-              "platformType": "fishing-vessel",
-              "platformTypeId": "id-fisher",
-              "uniqid": "a0pra000204"
+              platformType: 'fishing-vessel',
+              platformTypeId: 'id-fisher',
+              uniqid: 'a0pra000204'
             }
           ],
-          "color": "#0F0",
-          "dirty": false,
-          "iconURL": "default_img/umpireDefault.png",
-          "name": "Green",
-          "overview": "Green Shipping",
-          "roles": [
+          color: '#0F0',
+          dirty: false,
+          iconURL: 'default_img/umpireDefault.png',
+          name: 'Green',
+          overview: 'Green Shipping',
+          roles: [
             {
-              "isGameControl": false,
-              "isInsightViewer": false,
-              "isObserver": false,
-              "name": "CO",
-              "roleId": "rkrlw6f33"
+              isGameControl: false,
+              isInsightViewer: false,
+              isObserver: false,
+              name: 'CO',
+              roleId: 'rkrlw6f33'
             }
           ],
-          "umpire": false,
-          "uniqid": "Green"
+          umpire: false,
+          uniqid: 'Green'
         }
       ],
-      "name": "Forces",
-      "selectedForce": ""
+      name: 'Forces',
+      selectedForce: ''
     },
-    "overview": {
-      "dirty": false,
-      "gameDate": "2021-05-13T16:12",
-      "gameDescription": "",
-      "gameTurnTime": { "unit": "millis", "millis": 43200000 },
-      "name": "Overview - settings",
-      "realtimeTurnTime": 300000,
-      "showAccessCodes": true,
-      "timeWarning": 60000,
-      "turnPresentation": "Turn-Pair-Letters"
+    overview: {
+      dirty: false,
+      gameDate: '2021-05-13T16:12',
+      gameDescription: '',
+      gameTurnTime: { unit: 'millis', millis: 43200000 },
+      name: 'Overview - settings',
+      realtimeTurnTime: 300000,
+      showAccessCodes: true,
+      timeWarning: 60000,
+      turnPresentation: 'Turn-Pair-Letters'
     },
-    "platformTypes": {
-      "dirty": false,
-      "name": "Platform Types",
-      "platformTypes": [
+    platformTypes: {
+      dirty: false,
+      name: 'Platform Types',
+      platformTypes: [
         {
-          "attributeTypes": [
+          attributeTypes: [
             {
-              "attrId": "comm-fish",
-              "attrType": "AttributeTypeNumber",
-              "defaultValue": 100,
-              "description": "fishing allowance",
-              "editableByPlayer": false,
-              "name": "quota",
-              "units": "tonnes"
+              attrId: 'comm-fish',
+              attrType: 'AttributeTypeNumber',
+              defaultValue: 100,
+              description: 'fishing allowance',
+              editableByPlayer: false,
+              name: 'quota',
+              units: 'tonnes'
             },
             {
-              "attrId": "comm-fuel",
-              "attrType": "AttributeTypeNumber",
-              "defaultValue": 5,
-              "description": "fuel remaining",
-              "editableByPlayer": false,
-              "format": "0.00",
-              "name": "fuel",
-              "units": "tonnes"
+              attrId: 'comm-fuel',
+              attrType: 'AttributeTypeNumber',
+              defaultValue: 5,
+              description: 'fuel remaining',
+              editableByPlayer: false,
+              format: '0.00',
+              name: 'fuel',
+              units: 'tonnes'
             }
           ],
-          "conditions": [
-            "Full capability",
-            "Limited capability",
-            "Illegally boarded",
-            "Immobile",
-            "Sinking",
-            "Destroyed"
+          conditions: [
+            'Full capability',
+            'Limited capability',
+            'Illegally boarded',
+            'Immobile',
+            'Sinking',
+            'Destroyed'
           ],
-          "icon": "fishing-vessel.svg",
-          "name": "Fishing vessel",
-          "uniqid": "id-fisher",
-          "speedKts": [
-            10,
-            20
-          ],
-          "states": [
+          icon: 'fishing-vessel.svg',
+          name: 'Fishing vessel',
+          uniqid: 'id-fisher',
+          speedKts: [10, 20],
+          states: [
             {
-              "mobile": true,
-              "name": "Transiting"
+              mobile: true,
+              name: 'Transiting'
             },
             {
-              "mobile": false,
-              "name": "Fishing"
+              mobile: false,
+              name: 'Fishing'
             },
             {
-              "mobile": false,
-              "name": "Moored"
+              mobile: false,
+              name: 'Moored'
             }
           ],
-          "travelMode": "sea"
+          travelMode: 'sea'
         },
         {
-          "conditions": [
-            "Full capability",
-            "Limited capability",
-            "Immobile",
-            "Sinking",
-            "Destroyed"
+          conditions: [
+            'Full capability',
+            'Limited capability',
+            'Immobile',
+            'Sinking',
+            'Destroyed'
           ],
-          "icon": "mcmv.svg",
-          "name": "MCMV",
-          "uniqid": "id-mcm",
-          "speedKts": [
-            10
-          ],
-          "states": [
+          icon: 'mcmv.svg',
+          name: 'MCMV',
+          uniqid: 'id-mcm',
+          speedKts: [10],
+          states: [
             {
-              "mobile": true,
-              "name": "Transiting"
+              mobile: true,
+              name: 'Transiting'
             },
             {
-              "mobile": false,
-              "name": "Stopped"
+              mobile: false,
+              name: 'Stopped'
             },
             {
-              "mobile": false,
-              "name": "Moored"
+              mobile: false,
+              name: 'Moored'
             }
           ],
-          "travelMode": "sea"
+          travelMode: 'sea'
         },
         {
-          "conditions": [
-            "Working",
-            "Disabled",
-            "Mission Kill"
-          ],
-          "icon": "frigate.svg",
-          "name": "frigate",
-          "uniqid": "id-frigate",
-          "speedKts": [
-            6,
-            12,
-            18,
-            24
-          ],
-          "states": [
+          conditions: ['Working', 'Disabled', 'Mission Kill'],
+          icon: 'frigate.svg',
+          name: 'frigate',
+          uniqid: 'id-frigate',
+          speedKts: [6, 12, 18, 24],
+          states: [
             {
-              "mobile": true,
-              "name": "Transiting"
+              mobile: true,
+              name: 'Transiting'
             },
             {
-              "mobile": true,
-              "name": "Mixed"
+              mobile: true,
+              name: 'Mixed'
             },
             {
-              "mobile": true,
-              "name": "Active"
+              mobile: true,
+              name: 'Active'
             },
             {
-              "mobile": true,
-              "name": "Passive"
+              mobile: true,
+              name: 'Passive'
             }
           ],
-          "travelMode": "sea"
+          travelMode: 'sea'
         },
         {
-          "conditions": [
-            "Full capability",
-            "Limited capability",
-            "Immobile",
-            "Destroyed"
+          conditions: [
+            'Full capability',
+            'Limited capability',
+            'Immobile',
+            'Destroyed'
           ],
-          "icon": "uas.svg",
-          "name": "Unmanned Airborne Vehicle",
-          "uniqid": "id-uav",
-          "speedKts": [],
-          "states": [
+          icon: 'uas.svg',
+          name: 'Unmanned Airborne Vehicle',
+          uniqid: 'id-uav',
+          speedKts: [],
+          states: [
             {
-              "mobile": true,
-              "name": "Airborne"
+              mobile: true,
+              name: 'Airborne'
             },
             {
-              "mobile": false,
-              "name": "Landed"
+              mobile: false,
+              name: 'Landed'
             },
             {
-              "mobile": false,
-              "name": "Preparing for launch"
+              mobile: false,
+              name: 'Preparing for launch'
             }
           ],
-          "travelMode": "air"
+          travelMode: 'air'
         },
         {
-          "conditions": [
-            "Working",
-            "Disabled",
-            "Mission Kill"
-          ],
-          "icon": "frigate-ta.svg",
-          "name": "frigate-ta",
-          "uniqid": "id-frigate-ta",
-          "speedKts": [
-            6,
-            12,
-            18,
-            24
-          ],
-          "states": [
+          conditions: ['Working', 'Disabled', 'Mission Kill'],
+          icon: 'frigate-ta.svg',
+          name: 'frigate-ta',
+          uniqid: 'id-frigate-ta',
+          speedKts: [6, 12, 18, 24],
+          states: [
             {
-              "mobile": true,
-              "name": "Transiting"
+              mobile: true,
+              name: 'Transiting'
             },
             {
-              "mobile": true,
-              "name": "Mixed"
+              mobile: true,
+              name: 'Mixed'
             },
             {
-              "mobile": true,
-              "name": "Active"
+              mobile: true,
+              name: 'Active'
             },
             {
-              "mobile": true,
-              "name": "Passive"
+              mobile: true,
+              name: 'Passive'
             }
           ],
-          "travelMode": "sea"
+          travelMode: 'sea'
         },
         {
-          "conditions": [
-            "Working",
-            "Disabled",
-            "Mission Kill"
-          ],
-          "icon": "missile.svg",
-          "name": "Missile",
-          "uniqid": "id-missile",
-          "states": [
+          conditions: ['Working', 'Disabled', 'Mission Kill'],
+          icon: 'missile.svg',
+          name: 'Missile',
+          uniqid: 'id-missile',
+          states: [
             {
-              "mobile": false,
-              "name": "Inactive"
+              mobile: false,
+              name: 'Inactive'
             },
             {
-              "mobile": true,
-              "name": "Deployed"
+              mobile: true,
+              name: 'Deployed'
             }
           ],
-          "travelMode": "air"
+          travelMode: 'air'
         },
         {
-          "conditions": [
-            "Working",
-            "Disabled",
-            "Mission Kill"
-          ],
-          "icon": "carrier.svg",
-          "name": "Carrier",
-          "uniqid": "id-carrier",
-          "speedKts": [
-            6,
-            12,
-            18,
-            24,
-            30
-          ],
-          "states": [
+          conditions: ['Working', 'Disabled', 'Mission Kill'],
+          icon: 'carrier.svg',
+          name: 'Carrier',
+          uniqid: 'id-carrier',
+          speedKts: [6, 12, 18, 24, 30],
+          states: [
             {
-              "mobile": true,
-              "name": "Transiting"
+              mobile: true,
+              name: 'Transiting'
             },
             {
-              "mobile": true,
-              "name": "Air Ops"
+              mobile: true,
+              name: 'Air Ops'
             }
           ],
-          "travelMode": "sea"
+          travelMode: 'sea'
         },
         {
-          "conditions": [
-            "Working",
-            "Disabled",
-            "Mission Kill"
-          ],
-          "icon": "auxiliary.svg",
-          "name": "Auxiliary",
-          "uniqid": "id-auxiliary",
-          "speedKts": [
-            6,
-            12
-          ],
-          "states": [
+          conditions: ['Working', 'Disabled', 'Mission Kill'],
+          icon: 'auxiliary.svg',
+          name: 'Auxiliary',
+          uniqid: 'id-auxiliary',
+          speedKts: [6, 12],
+          states: [
             {
-              "mobile": true,
-              "name": "Transiting"
+              mobile: true,
+              name: 'Transiting'
             },
             {
-              "mobile": true,
-              "name": "Supporting"
+              mobile: true,
+              name: 'Supporting'
             }
           ],
-          "travelMode": "sea"
+          travelMode: 'sea'
         },
         {
-          "conditions": [
-            "Working",
-            "Disabled",
-            "Mission Kill"
-          ],
-          "icon": "destroyer.svg",
-          "name": "Destroyer",
-          "uniqid": "id-destroyer",
-          "speedKts": [
-            6,
-            12,
-            18,
-            24,
-            30
-          ],
-          "states": [
+          conditions: ['Working', 'Disabled', 'Mission Kill'],
+          icon: 'destroyer.svg',
+          name: 'Destroyer',
+          uniqid: 'id-destroyer',
+          speedKts: [6, 12, 18, 24, 30],
+          states: [
             {
-              "mobile": true,
-              "name": "Transiting"
+              mobile: true,
+              name: 'Transiting'
             },
             {
-              "mobile": false,
-              "name": "Loitering"
+              mobile: false,
+              name: 'Loitering'
             }
           ],
-          "travelMode": "sea"
+          travelMode: 'sea'
         },
         {
-          "conditions": [
-            "Working",
-            "Disabled",
-            "Mission Kill"
-          ],
-          "icon": "ssk.svg",
-          "name": "SSK",
-          "uniqid": "id-ssk",
-          "speedKts": [
-            6,
-            12,
-            18
-          ],
-          "states": [
+          conditions: ['Working', 'Disabled', 'Mission Kill'],
+          icon: 'ssk.svg',
+          name: 'SSK',
+          uniqid: 'id-ssk',
+          speedKts: [6, 12, 18],
+          states: [
             {
-              "mobile": true,
-              "name": "Transiting"
+              mobile: true,
+              name: 'Transiting'
             },
             {
-              "mobile": true,
-              "name": "Aggressove"
+              mobile: true,
+              name: 'Aggressove'
             },
             {
-              "mobile": true,
-              "name": "Evasive"
+              mobile: true,
+              name: 'Evasive'
             }
           ],
-          "travelMode": "sea"
+          travelMode: 'sea'
         },
         {
-          "conditions": [
-            "Working",
-            "Disabled",
-            "Mission Kill"
-          ],
-          "icon": "ssn.svg",
-          "name": "SSN",
-          "uniqid": "id-ssn",
-          "speedKts": [
-            6,
-            12,
-            18,
-            24
-          ],
-          "states": [
+          conditions: ['Working', 'Disabled', 'Mission Kill'],
+          icon: 'ssn.svg',
+          name: 'SSN',
+          uniqid: 'id-ssn',
+          speedKts: [6, 12, 18, 24],
+          states: [
             {
-              "mobile": true,
-              "name": "Transiting"
+              mobile: true,
+              name: 'Transiting'
             },
             {
-              "mobile": true,
-              "name": "Aggressove"
+              mobile: true,
+              name: 'Aggressove'
             },
             {
-              "mobile": true,
-              "name": "Evasive"
+              mobile: true,
+              name: 'Evasive'
             }
           ],
-          "travelMode": "sea"
+          travelMode: 'sea'
         },
         {
-          "conditions": [
-            "Working",
-            "Disabled",
-            "Mission Kill"
-          ],
-          "icon": "helicopter.svg",
-          "name": "Helicopter",
-          "uniqid": "id-helo",
-          "states": [
+          conditions: ['Working', 'Disabled', 'Mission Kill'],
+          icon: 'helicopter.svg',
+          name: 'Helicopter',
+          uniqid: 'id-helo',
+          states: [
             {
-              "mobile": true,
-              "name": "Active"
+              mobile: true,
+              name: 'Active'
             },
             {
-              "mobile": false,
-              "name": "Landed"
+              mobile: false,
+              name: 'Landed'
             }
           ],
-          "travelMode": "air"
+          travelMode: 'air'
         },
         {
-          "conditions": [
-            "Working",
-            "Disabled",
-            "Mission Kill"
-          ],
-          "icon": "mpa.svg",
-          "name": "mpa",
-          "uniqid": "id-mpa",
-          "states": [
+          conditions: ['Working', 'Disabled', 'Mission Kill'],
+          icon: 'mpa.svg',
+          name: 'mpa',
+          uniqid: 'id-mpa',
+          states: [
             {
-              "mobile": true,
-              "name": "Active"
+              mobile: true,
+              name: 'Active'
             },
             {
-              "mobile": false,
-              "name": "Landed"
+              mobile: false,
+              name: 'Landed'
             }
           ],
-          "travelMode": "air"
+          travelMode: 'air'
         },
         {
-          "conditions": [
-            "Working",
-            "Disabled",
-            "Mission Kill"
-          ],
-          "icon": "fixed-wing-aircraft.svg",
-          "name": "Fixed Wing Aircraft",
-          "uniqid": "id-fixed-wing",
-          "states": [
+          conditions: ['Working', 'Disabled', 'Mission Kill'],
+          icon: 'fixed-wing-aircraft.svg',
+          name: 'Fixed Wing Aircraft',
+          uniqid: 'id-fixed-wing',
+          states: [
             {
-              "mobile": true,
-              "name": "Active"
+              mobile: true,
+              name: 'Active'
             },
             {
-              "mobile": false,
-              "name": "Landed"
+              mobile: false,
+              name: 'Landed'
             }
           ],
-          "travelMode": "air"
+          travelMode: 'air'
         },
         {
-          "conditions": [
-            "Working",
-            "Disabled",
-            "Mission Kill"
-          ],
-          "icon": "merchant-vessel.svg",
-          "name": "Merchant vessel",
-          "uniqid": "id-merchant",
-          "speedKts": [
-            6,
-            12
-          ],
-          "states": [
+          conditions: ['Working', 'Disabled', 'Mission Kill'],
+          icon: 'merchant-vessel.svg',
+          name: 'Merchant vessel',
+          uniqid: 'id-merchant',
+          speedKts: [6, 12],
+          states: [
             {
-              "mobile": true,
-              "name": "Transiting"
+              mobile: true,
+              name: 'Transiting'
             },
             {
-              "mobile": false,
-              "name": "Moored"
+              mobile: false,
+              name: 'Moored'
             }
           ],
-          "travelMode": "sea"
+          travelMode: 'sea'
         },
         {
-          "conditions": [
-            "Working",
-            "Disabled",
-            "Mission Kill"
-          ],
-          "icon": "boghammer.svg",
-          "name": "Boghammer",
-          "uniqid": "id-boghammer",
-          "speedKts": [
-            6,
-            12,
-            18,
-            24,
-            30
-          ],
-          "states": [
+          conditions: ['Working', 'Disabled', 'Mission Kill'],
+          icon: 'boghammer.svg',
+          name: 'Boghammer',
+          uniqid: 'id-boghammer',
+          speedKts: [6, 12, 18, 24, 30],
+          states: [
             {
-              "mobile": true,
-              "name": "Transiting"
+              mobile: true,
+              name: 'Transiting'
             },
             {
-              "mobile": false,
-              "name": "Moored"
+              mobile: false,
+              name: 'Moored'
             }
           ],
-          "travelMode": "sea"
+          travelMode: 'sea'
         },
         {
-          "conditions": [
-            "Working",
-            "Disabled",
-            "Mission Kill"
-          ],
-          "icon": "agi.svg",
-          "name": "AGI",
-          "uniqid": "id-agi",
-          "speedKts": [
-            6,
-            12,
-            18
-          ],
-          "states": [
+          conditions: ['Working', 'Disabled', 'Mission Kill'],
+          icon: 'agi.svg',
+          name: 'AGI',
+          uniqid: 'id-agi',
+          speedKts: [6, 12, 18],
+          states: [
             {
-              "mobile": true,
-              "name": "Transiting"
+              mobile: true,
+              name: 'Transiting'
             },
             {
-              "mobile": false,
-              "name": "Moored"
+              mobile: false,
+              name: 'Moored'
             }
           ],
-          "travelMode": "sea"
+          travelMode: 'sea'
         },
         {
-          "conditions": [
-            "Working",
-            "Disabled",
-            "Mission Kill"
-          ],
-          "icon": "task-group.svg",
-          "name": "Task Group",
-          "uniqid": "id-task-group",
-          "speedKts": [
-            6,
-            12,
-            18,
-            24,
-            30
-          ],
-          "states": [
+          conditions: ['Working', 'Disabled', 'Mission Kill'],
+          icon: 'task-group.svg',
+          name: 'Task Group',
+          uniqid: 'id-task-group',
+          speedKts: [6, 12, 18, 24, 30],
+          states: [
             {
-              "mobile": true,
-              "name": "Transiting"
+              mobile: true,
+              name: 'Transiting'
             },
             {
-              "mobile": false,
-              "name": "Stopped"
+              mobile: false,
+              name: 'Stopped'
             },
             {
-              "mobile": false,
-              "name": "Moored"
+              mobile: false,
+              name: 'Moored'
             }
           ],
-          "travelMode": "sea"
+          travelMode: 'sea'
         }
       ],
-      "selectedType": ""
+      selectedType: ''
     }
   },
-  "gameTurn": 6,
-  "infoType": true,
-  "messageType": "InfoMessage",
-  "name": "wargame-l6nngxlk",
-  "phase": "planning",
-  "turnEndTime": "2021-08-10T16:17:26+01:00",
-  "wargameInitiated": true,
-  "wargameTitle": "P9 Test"
-}
+  gameTurn: 6,
+  infoType: true,
+  messageType: 'InfoMessage',
+  name: 'wargame-l6nngxlk',
+  phase: 'planning',
+  turnEndTime: '2021-08-10T16:17:26+01:00',
+  wargameInitiated: true,
+  wargameTitle: 'P9 Test'
+};
 
-export default game
+export default game;

--- a/packages/mocks/p9.mock.ts
+++ b/packages/mocks/p9.mock.ts
@@ -364,7 +364,7 @@ const game: Wargame = {
                   by: 'Blue',
                   force: 'Green',
                   name: 'SHU’AI',
-                  typeId: 'id-fishing'
+                  typeId: 'id-fisher'
                 }
               ],
               platformTypeId: 'id-fisher',

--- a/packages/mocks/pre-initialised-forces.mock.ts
+++ b/packages/mocks/pre-initialised-forces.mock.ts
@@ -34,7 +34,6 @@ const forces: ForceData[] = [
                                 name: "Dart 45",
                                 perceptions: [
                                 ],
-                                platformType: "Unmanned-Airborne-Vehicle",
                                 platformTypeId : 'a10',
                                 uniqid: "a0pra43302"
                             },
@@ -44,7 +43,6 @@ const forces: ForceData[] = [
                                 name: "Dart 46",
                                 perceptions: [
                                 ],
-                                platformType: "Unmanned-Airborne-Vehicle",
                                 platformTypeId : 'a10',
                                 uniqid: "a0pra17943"
                             }
@@ -52,7 +50,6 @@ const forces: ForceData[] = [
                         name: "Frigate A",
                         perceptions: [
                         ],
-                        platformType: "frigate",
                         platformTypeId : 'a3',
                         uniqid: "a0prbr6441"
                     },
@@ -62,7 +59,6 @@ const forces: ForceData[] = [
                         name: "MCM Delta",
                         perceptions: [
                         ],
-                        platformType: "MCMV",
                         platformTypeId : 'a7',
                         uniqid: "a0traa6790"
                     }
@@ -72,7 +68,6 @@ const forces: ForceData[] = [
                 name: "CTF 511",
                 perceptions: [
                 ],
-                platformType: "task-group",
                 platformTypeId : 'a11',
                 locationPending: LaydownTypes.UmpireLaydown,
                 uniqid: "a0pra5431"
@@ -87,7 +82,6 @@ const forces: ForceData[] = [
                         name: "Merlin",
                         perceptions: [
                         ],
-                        platformType: "helicopter",
                         platformTypeId : 'a8',
                         uniqid: "a0pra11002"
                     },
@@ -97,7 +91,6 @@ const forces: ForceData[] = [
                         name: "Dart 42",
                         perceptions: [
                         ],
-                        platformType: "Unmanned-Airborne-Vehicle",
                         platformTypeId : 'a10',
                         uniqid: "a0pra18702"
                     }
@@ -105,7 +98,6 @@ const forces: ForceData[] = [
                 name: "Frigate",
                 perceptions: [
                 ],
-                platformType: "frigate",
                 platformTypeId : 'a3',
 
                 locationPending: LaydownTypes.UmpireLaydown,
@@ -117,7 +109,6 @@ const forces: ForceData[] = [
                 name: "MPA",
                 perceptions: [
                 ],
-                platformType: "fixed-wing-aircraft",
                 platformTypeId : 'a9',
                 locationPending: LaydownTypes.UmpireLaydown,
                 uniqid: "a0pra00002"
@@ -128,7 +119,6 @@ const forces: ForceData[] = [
                 name: "Tanker",
                 perceptions: [
                 ],
-                platformType: "merchant-vessel",
                 platformTypeId : 'a13',
                 locationPending: LaydownTypes.UmpireLaydown,
                 uniqid: "a0pra00003"
@@ -167,7 +157,6 @@ const forces: ForceData[] = [
                 name: "Dhow-A",
                 perceptions: [
                 ],
-                platformType: "fishing-vessel",
                 platformTypeId : 'a1',
                 uniqid: "a0pra000100"
             },
@@ -181,7 +170,6 @@ const forces: ForceData[] = [
                         name: "Bog Draft",
                         perceptions: [
                         ],
-                        platformType: "boghammer",
                         platformTypeId : 'a4',
                         uniqid: "a0pra153102"
                     }
@@ -190,7 +178,6 @@ const forces: ForceData[] = [
                 name: "Dhow-B",
                 perceptions: [
                 ],
-                platformType: "fishing-vessel",
                 platformTypeId : 'a1',
                 uniqid: "a0pra000101"
             },
@@ -201,7 +188,6 @@ const forces: ForceData[] = [
                 name: "Dhow-C",
                 perceptions: [
                 ],
-                platformType: "fishing-vessel",
                 platformTypeId : 'a1',
                 uniqid: "a0pra000102"
             },
@@ -212,7 +198,6 @@ const forces: ForceData[] = [
                 name: "Missile-A",
                 perceptions: [
                 ],
-                platformType: "coastal-radar-site",
                 platformTypeId : 'a12',
                 uniqid: "a0pra000103"
             }
@@ -249,7 +234,6 @@ const forces: ForceData[] = [
                 name: "Tanker-1",
                 perceptions: [
                 ],
-                platformType: "merchant-vessel",
                 platformTypeId : 'a13',
                 locationPending: LaydownTypes.UmpireLaydown,
                 uniqid: "a0pra000200"
@@ -260,7 +244,6 @@ const forces: ForceData[] = [
                 name: "Tanker-2",
                 perceptions: [
                 ],
-                platformType: "merchant-vessel",
                 platformTypeId : 'a13',
                 locationPending: LaydownTypes.UmpireLaydown,
                 uniqid: "a0pra000201"
@@ -271,7 +254,6 @@ const forces: ForceData[] = [
                 name: "Fisher-A",
                 perceptions: [
                 ],
-                platformType: "fishing-vessel",
                 platformTypeId : 'a8',
                 locationPending: LaydownTypes.UmpireLaydown,
                 uniqid: "a0pra000202"
@@ -282,7 +264,6 @@ const forces: ForceData[] = [
                 name: "Fisher-B",
                 perceptions: [
                 ],
-                platformType: "fishing-vessel",
                 platformTypeId : 'a8',
                 locationPending: LaydownTypes.UmpireLaydown,
                 uniqid: "a0pra000203"
@@ -293,7 +274,6 @@ const forces: ForceData[] = [
                 name: "Fisher-C",
                 perceptions: [
                 ],
-                platformType: "fishing-vessel",
                 platformTypeId : 'a8',
                 locationPending: LaydownTypes.UmpireLaydown,
                 uniqid: "a0pra000204"

--- a/packages/mocks/small-forces.mock.ts
+++ b/packages/mocks/small-forces.mock.ts
@@ -76,7 +76,6 @@ export const forces: ForceData[] = [
             turn: 5
           }
         ],
-        platformType: 'frigate',
         platformTypeId : 'a3',
         position: 'L04',
         status: {
@@ -130,7 +129,6 @@ export const forces: ForceData[] = [
             turn: 5
           }
         ],
-        platformType: 'frigate',
         platformTypeId : 'a3',
         position: 'L04',
         status: {
@@ -233,7 +231,6 @@ export const forces: ForceData[] = [
             turn: 5
           }
         ],
-        platformType: 'fishing-vessel',
         platformTypeId : 'a1',
         status: {
           speedKts: 10,
@@ -304,7 +301,6 @@ export const forces: ForceData[] = [
             turn: 4
           },
         ],
-        platformType: 'merchant-vessel',
         platformTypeId : 'a13',
         position: 'M04',
         status: {

--- a/packages/mocks/small-forces.mock.ts
+++ b/packages/mocks/small-forces.mock.ts
@@ -48,7 +48,7 @@ export const forces: ForceData[] = [
         hosting: [],
         perceptions: [{
           by: 'Red',
-          force: 'Blue',
+          force: 'F-Blue',
           name: 'Frigate Perceived Name',
           typeId: 'frigate'
         }],
@@ -102,7 +102,7 @@ export const forces: ForceData[] = [
         hosting: [],
         perceptions: [{
           by: 'Red',
-          force: 'Blue',
+          force: 'F-Blue',
           name: 'Frigate Perceived Name',
           typeId: 'frigate'
         }],
@@ -163,7 +163,7 @@ export const forces: ForceData[] = [
 
     ],
     umpire: false,
-    uniqid: 'Blue'
+    uniqid: 'F-Blue'
   },
   {
     assets: [
@@ -256,7 +256,7 @@ export const forces: ForceData[] = [
       }
     ],
     umpire: false,
-    uniqid: 'Red'
+    uniqid: 'F-Red'
   },
   {
     assets: [
@@ -276,7 +276,7 @@ export const forces: ForceData[] = [
         name: 'Tanker-1',
         perceptions: [{
           by: 'Blue',
-          force: 'Green',
+          force: 'F-Green',
           name: 'OSAKA',
           typeId: 'merchant-vessel'
         }],
@@ -329,7 +329,7 @@ export const forces: ForceData[] = [
       }
     ],
     umpire: false,
-    uniqid: 'Green'
+    uniqid: 'F-Green'
   }
 ]
 

--- a/packages/mocks/small-scale-forces.mock.ts
+++ b/packages/mocks/small-scale-forces.mock.ts
@@ -89,7 +89,6 @@ export const forces: ForceData[] = [
           }
         ],
         "perceptions": [],
-        "platformType": "ssn",
         "platformTypeId" : "a2",
         "plannedTurns": [
           {
@@ -141,7 +140,6 @@ export const forces: ForceData[] = [
             "force": "Blue-1"
           }
         ],
-        "platformType": "frigate",
         "platformTypeId" : "a3",
         "position": "8718aab6cffffff",
         "uniqid": "a0prbr1141"

--- a/packages/mocks/wargame-exported.mock.ts
+++ b/packages/mocks/wargame-exported.mock.ts
@@ -236,7 +236,6 @@ const game: Wargame = {
                     force: 'Blue',
                     name: 'Frigate A Perceived Name'
                   }],
-                  platformType: 'frigate',
                   platformTypeId: 'dummy-val',
                   hosting: [
                     {
@@ -252,7 +251,6 @@ const game: Wargame = {
                         typeId: 'Unmanned-Airborne-Vehicle',
                       }],
                       plannedTurns: [],
-                      platformType: 'Unmanned-Airborne-Vehicle',
                       platformTypeId: 'dummy-val',
                       status: {
                         state: 'Landed'
@@ -267,7 +265,6 @@ const game: Wargame = {
                       name: 'Dart 46',
                       perceptions: [],
                       plannedTurns: [],
-                      platformType: 'Unmanned-Airborne-Vehicle',
                       platformTypeId: 'dummy-val',
                       status: {
                         state: 'Landed'
@@ -288,7 +285,6 @@ const game: Wargame = {
                   ],
                   name: 'MCM Delta',
                   perceptions: [],
-                  platformType: 'MCMV',
                   platformTypeId: 'dummy-val',
                   status: {
                     speedKts: 20,
@@ -328,7 +324,6 @@ const game: Wargame = {
                   turn: 5
                 }
               ],
-              platformType: 'task-group',
               platformTypeId: 'dummy-val',
               position: 'P19',
               status: {
@@ -364,7 +359,6 @@ const game: Wargame = {
                     typeId: 'helicopter'
                   }],
                   plannedTurns: [],
-                  platformType: 'helicopter',
                   platformTypeId: 'dummy-val',
                   status: {
                     state: 'Landed'
@@ -379,7 +373,6 @@ const game: Wargame = {
                   name: 'Dart 42',
                   perceptions: [],
                   plannedTurns: [],
-                  platformType: 'Unmanned-Airborne-Vehicle',
                   platformTypeId: 'dummy-val',
                   status: {
                     state: 'Landed'
@@ -417,7 +410,6 @@ const game: Wargame = {
                   turn: 5
                 }
               ],
-              platformType: 'frigate',
               platformTypeId: 'dummy-val',
               position: 'P21',
               status: {
@@ -434,7 +426,6 @@ const game: Wargame = {
               name: 'MPA',
               perceptions: [],
               plannedTurns: [],
-              platformType: 'fixed-wing-aircraft',
               platformTypeId: 'dummy-val',
               position: 'C17',
               status: {
@@ -496,7 +487,6 @@ const game: Wargame = {
                   turn: 6
                 }
               ],
-              platformType: 'merchant-vessel',
               platformTypeId: 'dummy-val',
               position: 'O21',
               status: {
@@ -592,7 +582,6 @@ const game: Wargame = {
                   turn: 5
                 }
               ],
-              platformType: 'fishing-vessel',
               platformTypeId: 'dummy-val',
               position: 'M04',
               status: {
@@ -624,7 +613,6 @@ const game: Wargame = {
                   name: 'Bog Draft',
                   perceptions: [],
                   plannedTurns: [],
-                  platformType: 'boghammer',
                   platformTypeId: 'dummy-val',
                   status: {
                     speedKts: 10,
@@ -684,7 +672,6 @@ const game: Wargame = {
                   turn: 7
                 }
               ],
-              platformType: 'fishing-vessel',
               platformTypeId: 'dummy-val',
               position: 'M10',
               status: {
@@ -740,7 +727,6 @@ const game: Wargame = {
                   turn: 5
                 }
               ],
-              platformType: 'fishing-vessel',
               platformTypeId: 'dummy-val',
               position: 'P17',
               status: {
@@ -765,7 +751,6 @@ const game: Wargame = {
               name: 'Missile-A',
               perceptions: [],
               plannedTurns: [],
-              platformType: 'coastal-radar-site',
               platformTypeId: 'dummy-val',
               position: 'Q12',
               status: {
@@ -911,7 +896,6 @@ const game: Wargame = {
                   turn: 11
                 }
               ],
-              platformType: 'merchant-vessel',
               platformTypeId: 'dummy-val',
               position: 'H03',
               status: {
@@ -1066,7 +1050,6 @@ const game: Wargame = {
                   turn: 11
                 }
               ],
-              platformType: 'merchant-vessel',
               platformTypeId: 'dummy-val',
               position: 'C00',
               status: {
@@ -1180,7 +1163,6 @@ const game: Wargame = {
                   turn: 11
                 }
               ],
-              platformType: 'fishing-vessel',
               platformTypeId: 'dummy-val',
               position: 'K03',
               status: {
@@ -1295,7 +1277,6 @@ const game: Wargame = {
                   turn: 12
                 }
               ],
-              platformType: 'fishing-vessel',
               platformTypeId: 'dummy-val',
               position: 'L09',
               status: {
@@ -1418,7 +1399,6 @@ const game: Wargame = {
                   turn: 11
                 }
               ],
-              platformType: 'fishing-vessel',
               platformTypeId: 'dummy-val',
               position: 'N11',
               status: {

--- a/packages/mocks/watu-playtest-mock.ts
+++ b/packages/mocks/watu-playtest-mock.ts
@@ -363,7 +363,6 @@ const wargame: Wargame = {
                             "uniqid": "al65069c1",
                             "contactId": "C777",
                             "name": "B1",
-                            "platformType": "Destroyer",
                             "platformTypeId": "a6",
                             "perceptions": [
                                 {
@@ -494,7 +493,6 @@ const wargame: Wargame = {
                             "uniqid": "al6506vlq",
                             "contactId": "C813",
                             "name": "B2",
-                            "platformType": "Frigate",
                             "platformTypeId": "a1",
                             "perceptions": [
                                 {
@@ -647,7 +645,6 @@ const wargame: Wargame = {
                             "uniqid": "al65088ae",
                             "contactId": "C166",
                             "name": "B3",
-                            "platformType": "Frigate",
                             "platformTypeId": "a1",
                             "perceptions": [
                                 {
@@ -854,7 +851,6 @@ const wargame: Wargame = {
                             "uniqid": "al6509vwo",
                             "contactId": "C101",
                             "name": "B4",
-                            "platformType": "Frigate",
                             "platformTypeId": "a1",
                             "perceptions": [
                                 {
@@ -1018,7 +1014,6 @@ const wargame: Wargame = {
                             "uniqid": "al650arbp",
                             "contactId": "C955",
                             "name": "B5",
-                            "platformType": "Frigate",
                             "platformTypeId": "a1",
                             "perceptions": [
                                 {
@@ -1176,7 +1171,6 @@ const wargame: Wargame = {
                             "uniqid": "al650d18r",
                             "contactId": "C347",
                             "name": "R1",
-                            "platformType": "SSK",
                             "platformTypeId": "a7",
                             "perceptions": [],
                             "condition": "Working",
@@ -1259,7 +1253,6 @@ const wargame: Wargame = {
                             "uniqid": "al650dmnf",
                             "contactId": "C025",
                             "name": "R2",
-                            "platformType": "SSK",
                             "platformTypeId": "a7",
                             "perceptions": [
                                 {
@@ -1355,7 +1348,6 @@ const wargame: Wargame = {
                                     "name": "G1"
                                 }
                             ],
-                            "platformType": "Merchant vessel",
                             "platformTypeId": "a13",
                             "uniqid": "al63ltw3g",
                             "position": "8919501214bffff",
@@ -1544,7 +1536,6 @@ const wargame: Wargame = {
                                     "name": "G2"
                                 }
                             ],
-                            "platformType": "Merchant vessel",
                             "platformTypeId": "a13",
                             "uniqid": "al63ltwtw",
                             "position": "89195010583ffff",
@@ -1662,7 +1653,6 @@ const wargame: Wargame = {
                             "uniqid": "al650ez1f",
                             "contactId": "C632",
                             "name": "G3",
-                            "platformType": "Merchant vessel",
                             "platformTypeId": "a13",
                             "perceptions": [
                                 {
@@ -1832,7 +1822,6 @@ const wargame: Wargame = {
                             "uniqid": "al650f5k2",
                             "contactId": "C404",
                             "name": "G4",
-                            "platformType": "Merchant vessel",
                             "platformTypeId": "a13",
                             "perceptions": [
                                 {
@@ -1984,7 +1973,6 @@ const wargame: Wargame = {
                             "uniqid": "al650f123",
                             "contactId": "C604",
                             "name": "G5",
-                            "platformType": "Merchant vessel",
                             "platformTypeId": "a13",
                             "perceptions": [
                                 {
@@ -2183,7 +2171,6 @@ const wargame: Wargame = {
                             "uniqid": "al650f456",
                             "contactId": "C914",
                             "name": "G6",
-                            "platformType": "Merchant vessel",
                             "platformTypeId": "a13",
                             "perceptions": [
                                 {

--- a/packages/mocks/watu-wargame-mock.ts
+++ b/packages/mocks/watu-wargame-mock.ts
@@ -215,7 +215,6 @@ const wargame: Wargame = {
                                         }
                                     ],
                                     "plannedTurns": [],
-                                    "platformType": "helicopter",
                                     "platformTypeId": "a8",
                                     "status": {
                                         "state": "Landed"
@@ -229,7 +228,6 @@ const wargame: Wargame = {
                                     "name": "Dart 42",
                                     "perceptions": [],
                                     "plannedTurns": [],
-                                    "platformType": "Unmanned-Airborne-Vehicle",
                                     "platformTypeId": "a10",
                                     "status": {
                                         "state": "Landed"
@@ -411,7 +409,6 @@ const wargame: Wargame = {
                                             "typeId": "a3"
                                         }
                                     ],
-                                    "platformType": "frigate",
                                     "platformTypeId": "a3",
                                     "hosting": [
                                         {
@@ -428,7 +425,6 @@ const wargame: Wargame = {
                                                 }
                                             ],
                                             "plannedTurns": [],
-                                            "platformType": "Unmanned-Airborne-Vehicle",
                                             "platformTypeId": "a10",
                                             "status": {
                                                 "state": "Landed"
@@ -442,7 +438,6 @@ const wargame: Wargame = {
                                             "name": "Dart 46",
                                             "perceptions": [],
                                             "plannedTurns": [],
-                                            "platformType": "Unmanned-Airborne-Vehicle",
                                             "platformTypeId": "a10",
                                             "status": {
                                                 "state": "Landed"
@@ -464,7 +459,6 @@ const wargame: Wargame = {
                                     "perceptions": [
                                         { "by": "Red-1", "force": "Blue-1", "name": "Blue MCM", "typeId": "a9" }
                                     ],
-                                    "platformType": "MCMV",
                                     "platformTypeId": "a9",
                                     "status": {
                                         "speedKts": 20,
@@ -505,7 +499,6 @@ const wargame: Wargame = {
                                     "turn": 5
                                 }
                             ],
-                            "platformType": "task-group",
                             "platformTypeId": "a16",
                             "position": "8918aab0d07ffff",
                             "status": {
@@ -595,7 +588,6 @@ const wargame: Wargame = {
                                     },
                                     "turn": 4
                                 }],
-                            "platformType": "agi",
                             "platformTypeId": "a15",
                             "position": "8918a84db3bffff",
                             "uniqid": "red-AGI"


### PR DESCRIPTION
In some test data we're mistakenly using platformType.name, instead of platformType.id