### PR TITLE
Disambiguate force names and IDs.

### DIFF
--- a/packages/mocks/p9.mock.ts
+++ b/packages/mocks/p9.mock.ts
@@ -165,7 +165,7 @@ const game: Wargame = {
                       name: 'Dart 45',
                       perceptions: [
                         {
-                          by: 'Red',
+                          by: 'F-Red',
                           force: 'F-Blue',
                           name: 'Unknown UAV',
                           typeId: 'id-uav'
@@ -193,7 +193,7 @@ const game: Wargame = {
                   platformTypeId: 'id-frigate',
                   perceptions: [
                     {
-                      by: 'Red',
+                      by: 'F-Red',
                       force: 'F-Blue',
                       name: 'Frigate A Perceived Name'
                     }
@@ -214,7 +214,7 @@ const game: Wargame = {
               name: 'CTF 511',
               perceptions: [
                 {
-                  by: 'Red',
+                  by: 'F-Red',
                   force: 'F-Blue',
                   name: 'BRIT',
                   typeId: 'id-task-group'
@@ -239,7 +239,7 @@ const game: Wargame = {
                   name: 'Merlin',
                   perceptions: [
                     {
-                      by: 'Red',
+                      by: 'F-Red',
                       force: 'F-Blue',
                       typeId: 'id-helo'
                     }
@@ -268,7 +268,7 @@ const game: Wargame = {
               name: 'Frigate',
               perceptions: [
                 {
-                  by: 'Red',
+                  by: 'F-Red',
                   force: 'F-Blue',
                   name: 'Frigate Perceived Name',
                   typeId: 'id-frigate'
@@ -300,7 +300,7 @@ const game: Wargame = {
               name: 'Tanker',
               perceptions: [
                 {
-                  by: 'Red',
+                  by: 'F-Red',
                   force: 'F-Blue',
                   typeId: ''
                 }
@@ -335,7 +335,7 @@ const game: Wargame = {
               name: 'Dhow-A',
               perceptions: [
                 {
-                  by: 'Blue'
+                  by: 'F-Blue'
                 }
               ],
               platformTypeId: 'id-fisher',
@@ -361,7 +361,7 @@ const game: Wargame = {
               name: 'Dhow-B',
               perceptions: [
                 {
-                  by: 'Blue',
+                  by: 'F-Blue',
                   force: 'Green',
                   name: 'SHU’AI',
                   typeId: 'id-fisher'
@@ -415,7 +415,7 @@ const game: Wargame = {
               name: 'Tanker-1',
               perceptions: [
                 {
-                  by: 'Blue',
+                  by: 'F-Blue',
                   force: 'Green',
                   name: 'OSAKA',
                   typeId: 'id-merchant'
@@ -431,13 +431,13 @@ const game: Wargame = {
               name: 'Tanker-2',
               perceptions: [
                 {
-                  by: 'Blue',
+                  by: 'F-Blue',
                   force: 'Green',
                   name: 'ARUNA 12',
                   typeId: 'id-merchant'
                 },
                 {
-                  by: 'Red',
+                  by: 'F-Red',
                   force: 'Green',
                   name: 'BARLAY',
                   typeId: 'id-merchant'
@@ -456,7 +456,7 @@ const game: Wargame = {
               name: 'Fisher-A',
               perceptions: [
                 {
-                  by: 'Blue',
+                  by: 'F-Blue',
                   force: 'Green',
                   name: 'JALIBUT',
                   typeId: 'id-merchant'
@@ -471,7 +471,7 @@ const game: Wargame = {
               name: 'Fisher-B',
               perceptions: [
                 {
-                  by: 'Blue',
+                  by: 'F-Blue',
                   force: 'Green',
                   typeId: 'id-merchant'
                 }
@@ -490,13 +490,13 @@ const game: Wargame = {
               name: 'Fisher-C',
               perceptions: [
                 {
-                  by: 'Blue',
+                  by: 'F-Blue',
                   force: 'Green',
                   name: 'BOUM 3',
                   typeId: 'id-merchant'
                 },
                 {
-                  by: 'Red',
+                  by: 'F-Red',
                   force: 'Green',
                   name: 'BOUM 3',
                   typeId: 'id-merchant'

--- a/packages/mocks/p9.mock.ts
+++ b/packages/mocks/p9.mock.ts
@@ -12,7 +12,7 @@ const game: Wargame = {
           participants: [
             {
               force: 'CTF A',
-              forceUniqid: 'Blue',
+              forceUniqid: 'F-Blue',
               pType: 'ParticipantPlanning',
               roles: [],
               subscriptionId: 'hukqr',
@@ -24,8 +24,8 @@ const game: Wargame = {
               ]
             },
             {
-              force: 'Red',
-              forceUniqid: 'Red',
+              force: 'F-Red',
+              forceUniqid: 'F-Red',
               pType: 'ParticipantPlanning',
               roles: [],
               subscriptionId: 'hukqr',
@@ -53,7 +53,7 @@ const game: Wargame = {
           participants: [
             {
               force: 'CTF Y',
-              forceUniqid: 'Red',
+              forceUniqid: 'F-Red',
               roles: [],
               subscriptionId: '7bayi',
               pType: 'ParticipantChat'
@@ -75,7 +75,7 @@ const game: Wargame = {
             {
               pType: 'ParticipantCustom',
               force: 'CTF B',
-              forceUniqid: 'Blue',
+              forceUniqid: 'F-Blue',
               roles: [],
               subscriptionId: 'etkkn',
               templates: [
@@ -111,7 +111,7 @@ const game: Wargame = {
             {
               force: 'CTF Y',
               pType: 'ParticipantCustom',
-              forceUniqid: 'Red',
+              forceUniqid: 'F-Red',
               roles: [],
               subscriptionId: '3b3ww',
               templates: [
@@ -166,7 +166,7 @@ const game: Wargame = {
                       perceptions: [
                         {
                           by: 'Red',
-                          force: 'Blue',
+                          force: 'F-Blue',
                           name: 'Unknown UAV',
                           typeId: 'id-uav'
                         }
@@ -194,7 +194,7 @@ const game: Wargame = {
                   perceptions: [
                     {
                       by: 'Red',
-                      force: 'Blue',
+                      force: 'F-Blue',
                       name: 'Frigate A Perceived Name'
                     }
                   ],
@@ -215,7 +215,7 @@ const game: Wargame = {
               perceptions: [
                 {
                   by: 'Red',
-                  force: 'Blue',
+                  force: 'F-Blue',
                   name: 'BRIT',
                   typeId: 'id-task-group'
                 }
@@ -240,7 +240,7 @@ const game: Wargame = {
                   perceptions: [
                     {
                       by: 'Red',
-                      force: 'Blue',
+                      force: 'F-Blue',
                       typeId: 'id-helo'
                     }
                   ],
@@ -269,7 +269,7 @@ const game: Wargame = {
               perceptions: [
                 {
                   by: 'Red',
-                  force: 'Blue',
+                  force: 'F-Blue',
                   name: 'Frigate Perceived Name',
                   typeId: 'id-frigate'
                 }
@@ -301,7 +301,7 @@ const game: Wargame = {
               perceptions: [
                 {
                   by: 'Red',
-                  force: 'Blue',
+                  force: 'F-Blue',
                   typeId: ''
                 }
               ],
@@ -313,7 +313,7 @@ const game: Wargame = {
           color: '#00F',
           dirty: false,
           iconURL: 'default_img/umpireDefault.png',
-          name: 'Blue',
+          name: 'Blue Force',
           overview: 'Blue force.',
           roles: [
             {
@@ -325,7 +325,7 @@ const game: Wargame = {
             }
           ],
           umpire: false,
-          uniqid: 'Blue'
+          uniqid: 'F-Blue'
         },
         {
           assets: [
@@ -393,7 +393,7 @@ const game: Wargame = {
           color: '#F00',
           dirty: false,
           iconURL: 'default_img/umpireDefault.png',
-          name: 'Red',
+          name: 'Red Force',
           overview: 'Red force.',
           roles: [
             {
@@ -405,7 +405,7 @@ const game: Wargame = {
             }
           ],
           umpire: false,
-          uniqid: 'Red'
+          uniqid: 'F-Red'
         },
         {
           assets: [
@@ -509,7 +509,7 @@ const game: Wargame = {
           color: '#0F0',
           dirty: false,
           iconURL: 'default_img/umpireDefault.png',
-          name: 'Green',
+          name: 'Green Force',
           overview: 'Green Shipping',
           roles: [
             {
@@ -521,7 +521,7 @@ const game: Wargame = {
             }
           ],
           umpire: false,
-          uniqid: 'Green'
+          uniqid: 'F-Green'
         }
       ],
       name: 'Forces',


### PR DESCRIPTION
In the P9 demo data, we're using the same value for force.uniqid and force.name

This will prevent us "catching" use of the wrong value.  Make each one different.