### PR TITLE
Hotfix more force renaming & depracating

### DIFF
--- a/packages/client/src/Components/CollabChannel.tsx
+++ b/packages/client/src/Components/CollabChannel.tsx
@@ -65,7 +65,7 @@ const CollabChannel: React.FC<{ channelId: string }> = ({ channelId }) => {
     roleId: selectedRole,
     roleName: selectedRoleName
   }
-  const participationsForMyForce = channel.participants.filter((p: ParticipantCollab) => p.force === role.forceName)
+  const participationsForMyForce = channel.participants.filter((p: ParticipantCollab) => p.forceUniqid === role.forceId)
   // participations relate to me if they contain no roles, or if they contain my role
   const isParticipating = participationsForMyForce.filter((p: ParticipantCollab) => (p.roles.length === 0 || p.roles.includes(role.roleId)))
   // can I create messages in the channel?

--- a/packages/components/src/local/collab-status-board/helpers/assignees.spec.ts
+++ b/packages/components/src/local/collab-status-board/helpers/assignees.spec.ts
@@ -10,7 +10,6 @@ const namedWhite: ParticipantCollab[] = [
     canCreate: true,
     viewUnreleasedVersions: true,
     permission: CollaborativePermission.CanRelease,
-    force: 'White',
     forceUniqid: 'umpire',
     roles: ['rkrlw6f5f'],
     subscriptionId: 'jvrn'
@@ -23,7 +22,6 @@ const allWhiteCollaborate: ParticipantCollab[] = [
     canCreate: true,
     viewUnreleasedVersions: true,
     permission: CollaborativePermission.CanRelease,
-    force: 'White',
     forceUniqid: 'umpire',
     roles: [],
     subscriptionId: 'jvrn'
@@ -36,7 +34,6 @@ const allWhiteNonCollab: ParticipantCollab[] = [
     canCreate: true,
     viewUnreleasedVersions: false,
     permission: CollaborativePermission.CannotCollaborate,
-    force: 'White',
     forceUniqid: 'umpire',
     roles: [],
     subscriptionId: 'jvrn'
@@ -49,7 +46,6 @@ const multiPart: ParticipantCollab[] = [
     canCreate: true,
     viewUnreleasedVersions: true,
     permission: CollaborativePermission.CanRelease,
-    force: 'White',
     forceUniqid: 'umpire',
     roles: [],
     subscriptionId: 'jvrn'
@@ -59,7 +55,6 @@ const multiPart: ParticipantCollab[] = [
     canCreate: true,
     viewUnreleasedVersions: true,
     permission: CollaborativePermission.CanRelease,
-    force: 'Blue',
     forceUniqid: 'Blue',
     roles: [],
     subscriptionId: 'jvrn'

--- a/packages/components/src/local/collab-status-board/index.spec.tsx
+++ b/packages/components/src/local/collab-status-board/index.spec.tsx
@@ -30,7 +30,6 @@ const testChannelColb: ChannelCollab = {
       canCreate: true,
       viewUnreleasedVersions: true,
       permission: CollaborativePermission.CanSubmitForReview,
-      force: 'Blue',
       forceUniqid: 'Blue',
       roles: [],
       subscriptionId: 'oqoj'
@@ -40,7 +39,6 @@ const testChannelColb: ChannelCollab = {
       canCreate: true,
       viewUnreleasedVersions: true,
       permission: CollaborativePermission.CanRelease,
-      force: 'Blue',
       forceUniqid: 'Blue',
       roles: [blueCO.roleId],
       subscriptionId: 'oqoj2'

--- a/packages/components/src/local/collab-status-board/index.tsx
+++ b/packages/components/src/local/collab-status-board/index.tsx
@@ -22,7 +22,7 @@ export const CollabStatusBoard: React.FC<CollabStatusBoardProps> = ({
 }) => {
   const [showArchived, setShowArchived] = useState<boolean>(false)
 
-  const participationsForMyForce = channelColb.participants.filter((p: ParticipantCollab) => p.force === role.forceName)
+  const participationsForMyForce = channelColb.participants.filter((p: ParticipantCollab) => p.forceUniqid === role.forceId)
   // participations relate to me if they contain no roles, or if they contain my role
   const myParticipations = participationsForMyForce.filter((p: ParticipantCollab) => (p.roles.length === 0 || p.roles.includes(role.roleId)))
 

--- a/packages/components/src/local/molecules/collab-message-detail/index.spec.tsx
+++ b/packages/components/src/local/molecules/collab-message-detail/index.spec.tsx
@@ -27,7 +27,6 @@ const testCollabChannel: ChannelCollab = {
       canCreate: true,
       viewUnreleasedVersions: true,
       permission: CollaborativePermission.CanApprove,
-      force: 'White',
       forceUniqid: 'umpire',
       roles: [],
       subscriptionId: 'oqoj'

--- a/packages/components/src/local/organisms/setting-channels/channels/chat.tsx
+++ b/packages/components/src/local/organisms/setting-channels/channels/chat.tsx
@@ -65,7 +65,6 @@ export const ChatChannel: React.FC<ChatChannelProps> = ({
 
       return {
         ...participant,
-        force: selectedForce.name,
         forceUniqid: selectedForce.uniqid,
         roles
       }

--- a/packages/components/src/local/organisms/setting-channels/channels/collab.tsx
+++ b/packages/components/src/local/organisms/setting-channels/channels/collab.tsx
@@ -82,7 +82,6 @@ export const CollabChannel: React.FC<CollabChannelProps> = ({
       if (typeof seeLiveUpdates !== 'undefined') viewUnreleasedVersions = !!seeLiveUpdates.active
       return {
         ...participantCollab,
-        force: selectedForce.name,
         forceUniqid: selectedForce.uniqid,
         roles,
         permission,

--- a/packages/components/src/local/organisms/setting-channels/channels/custom.tsx
+++ b/packages/components/src/local/organisms/setting-channels/channels/custom.tsx
@@ -70,7 +70,6 @@ export const CustomChannel: React.FC<CustomChannelProps> = ({
 
       return {
         ...participant,
-        force: selectedForce.name,
         forceUniqid: selectedForce.uniqid,
         roles,
         templates

--- a/packages/components/src/local/organisms/setting-channels/channels/mapping.tsx
+++ b/packages/components/src/local/organisms/setting-channels/channels/mapping.tsx
@@ -73,7 +73,6 @@ export const MappingChannel: React.FC<MappingChannelProps> = ({
 
       return {
         ...participant,
-        force: selectedForce.name,
         forceUniqid: selectedForce.uniqid,
         roles,
         controls: controlsValues

--- a/packages/components/src/local/organisms/setting-channels/helpers/createChannel.ts
+++ b/packages/components/src/local/organisms/setting-channels/helpers/createChannel.ts
@@ -30,7 +30,6 @@ const createChannel = (
       case SpecialChannelTypes.CHANNEL_COLLAB: {
         // create new participant
         const participant: ParticipantCollab = {
-          force: defaultForce.name,
           forceUniqid: defaultForce.uniqid,
           roles: [],
           subscriptionId: Math.random().toString(36).substring(8),
@@ -56,7 +55,6 @@ const createChannel = (
       }
       case SpecialChannelTypes.CHANNEL_MAPPING: {
         const participant: ParticipantMapping = {
-          force: defaultForce.name,
           forceUniqid: defaultForce.uniqid,
           roles: [],
           subscriptionId: Math.random().toString(36).substring(8),
@@ -82,7 +80,6 @@ const createChannel = (
       case SpecialChannelTypes.CHANNEL_CHAT:
       default: {
         const participant: ParticipantChat = {
-          force: defaultForce.name,
           forceUniqid: defaultForce.uniqid,
           roles: [],
           subscriptionId: Math.random().toString(36).substring(8),
@@ -99,7 +96,6 @@ const createChannel = (
     }
   }
   const participant: ParticipantCustom = {
-    force: defaultForce.name,
     forceUniqid: defaultForce.uniqid,
     roles: [],
     subscriptionId: Math.random().toString(36).substring(8),

--- a/packages/custom-types/participant.d.ts
+++ b/packages/custom-types/participant.d.ts
@@ -10,8 +10,6 @@ export interface ParticipantTemplate {
 
 /** core properties for a participant */
 export interface CoreParticipant {
-  // Name of force being referred to @deprecated
-  readonly force: ForceData['name'],
   readonly forceUniqid: ForceData['uniqid'],
   // specific set of roles that participate in this channel (or empty for all roles)
   roles: Array<Role['roleId']>,

--- a/packages/helpers/src/tests/check-participation.spec.ts
+++ b/packages/helpers/src/tests/check-participation.spec.ts
@@ -12,7 +12,6 @@ const allForcesChannel: ChannelCustom = {
   channelType: CHANNEL_CUSTOM,
   participants: [
     {
-      force: 'White',
       forceUniqid: 'umpire',
       roles: [],
       subscriptionId: 'k63pjpfv',
@@ -20,7 +19,6 @@ const allForcesChannel: ChannelCustom = {
       templates: []
     },
     {
-      force: 'Red',
       forceUniqid: 'Red',
       roles: [redLogs.roleId],
       subscriptionId: 'k63pjsbv',
@@ -28,7 +26,6 @@ const allForcesChannel: ChannelCustom = {
       templates: []
     },
     {
-      force: 'Blue',
       forceUniqid: 'Blue',
       roles: [],
       subscriptionId: 'k63pju7l',

--- a/packages/helpers/src/tests/handle-channel-updates.spec.ts
+++ b/packages/helpers/src/tests/handle-channel-updates.spec.ts
@@ -162,8 +162,8 @@ describe('handle channel update for info message', () => {
       channelType: CHANNEL_CUSTOM,
       name: 'Blue Net 2',
       participants: [
-        { force: 'White', forceUniqid: 'umpire', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pk0d3', pType: PARTICIPANT_CUSTOM, templates: [] },
-        { force: 'Blue', forceUniqid: 'Blue', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pk2o6', pType: PARTICIPANT_CUSTOM, templates: [] }],
+        { forceUniqid: 'umpire', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pk0d3', pType: PARTICIPANT_CUSTOM, templates: [] },
+        { forceUniqid: 'Blue', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pk2o6', pType: PARTICIPANT_CUSTOM, templates: [] }],
       uniqid: 'channel-k63pjv111'
     }
     copyChannels.push(newChannel)
@@ -191,8 +191,8 @@ describe('handle channel update for info message', () => {
       name: 'Blue Net 2',
       channelType: CHANNEL_CUSTOM,
       participants: [
-        { force: 'White', forceUniqid: 'umpire', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pk0d3', pType: PARTICIPANT_CUSTOM, templates: [] },
-        { force: 'Blue', forceUniqid: 'Blue', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pk2o6', pType: PARTICIPANT_CUSTOM, templates: [] }],
+        { forceUniqid: 'umpire', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pk0d3', pType: PARTICIPANT_CUSTOM, templates: [] },
+        { forceUniqid: 'Blue', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pk2o6', pType: PARTICIPANT_CUSTOM, templates: [] }],
       uniqid: 'channel-k63pjv111'
     }
     copyChannels.push(newChannel)

--- a/packages/helpers/src/tests/is-chat-channel.spec.ts
+++ b/packages/helpers/src/tests/is-chat-channel.spec.ts
@@ -9,9 +9,9 @@ const empty: ChannelCustom = {
   channelType: CHANNEL_CUSTOM,
   name: 'Channel 16',
   participants: [
-    { force: 'White', forceUniqid: 'umpire', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pjpfv', templates: [], pType: PARTICIPANT_CUSTOM },
-    { force: 'Red', forceUniqid: 'Red', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pjsbv', templates: [], pType: PARTICIPANT_CUSTOM },
-    { force: 'Blue', forceUniqid: 'Blue', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pju7l', templates: [], pType: PARTICIPANT_CUSTOM }
+    { forceUniqid: 'umpire', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pjpfv', templates: [], pType: PARTICIPANT_CUSTOM },
+    { forceUniqid: 'Red', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pjsbv', templates: [], pType: PARTICIPANT_CUSTOM },
+    { forceUniqid: 'Blue', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pju7l', templates: [], pType: PARTICIPANT_CUSTOM }
   ] as ParticipantCustom[],
   uniqid: 'channel-k63pjit0'
 }
@@ -20,9 +20,9 @@ const chat: ChannelCustom = {
   channelType: CHANNEL_CUSTOM,
   name: 'Channel 16',
   participants: [
-    { force: 'White', forceUniqid: 'umpire', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pjpfv', templates: [], pType: PARTICIPANT_CUSTOM },
-    { force: 'Red', forceUniqid: 'Red', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pjsbv', templates: [{ title: 'Chat', _id: 'k16eedkl' }], pType: PARTICIPANT_CUSTOM },
-    { force: 'Blue', forceUniqid: 'Blue', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pju7l', templates: [], pType: PARTICIPANT_CUSTOM }
+    { forceUniqid: 'umpire', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pjpfv', templates: [], pType: PARTICIPANT_CUSTOM },
+    { forceUniqid: 'Red', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pjsbv', templates: [{ title: 'Chat', _id: 'k16eedkl' }], pType: PARTICIPANT_CUSTOM },
+    { forceUniqid: 'Blue', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pju7l', templates: [], pType: PARTICIPANT_CUSTOM }
   ] as ParticipantCustom[],
   uniqid: 'channel-k63pjit0'
 }
@@ -31,9 +31,9 @@ const mixed: ChannelCustom = {
   channelType: CHANNEL_CUSTOM,
   name: 'Channel 16',
   participants: [
-    { force: 'White', forceUniqid: 'umpire', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pjpfv', templates: [{ title: 'Weather', _id: 'weather' }, { title: 'Chat', _id: 'k16eedkl' }], pType: PARTICIPANT_CUSTOM },
-    { force: 'Red', forceUniqid: 'Red', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pjsbv', templates: [{ title: 'Chat', _id: 'k16eedkl' }], pType: PARTICIPANT_CUSTOM },
-    { force: 'Blue', forceUniqid: 'Blue', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pju7l', templates: [], pType: PARTICIPANT_CUSTOM }
+    { forceUniqid: 'umpire', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pjpfv', templates: [{ title: 'Weather', _id: 'weather' }, { title: 'Chat', _id: 'k16eedkl' }], pType: PARTICIPANT_CUSTOM },
+    { forceUniqid: 'Red', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pjsbv', templates: [{ title: 'Chat', _id: 'k16eedkl' }], pType: PARTICIPANT_CUSTOM },
+    { forceUniqid: 'Blue', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pju7l', templates: [], pType: PARTICIPANT_CUSTOM }
   ] as ParticipantCustom[],
   uniqid: 'channel-k63pjit0'
 }
@@ -42,9 +42,9 @@ const nonChat: ChannelCustom = {
   channelType: CHANNEL_CUSTOM,
   name: 'Channel 16',
   participants: [
-    { force: 'White', forceUniqid: 'umpire', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pjpfv', templates: [{ title: 'RFI', _id: 'rfi' }], pType: PARTICIPANT_CUSTOM },
-    { force: 'Red', forceUniqid: 'Red', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pjsbv', templates: [{ title: 'Weather', _id: 'weather' }], pType: PARTICIPANT_CUSTOM },
-    { force: 'Blue', forceUniqid: 'Blue', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pju7l', templates: [], pType: PARTICIPANT_CUSTOM }
+    { forceUniqid: 'umpire', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pjpfv', templates: [{ title: 'RFI', _id: 'rfi' }], pType: PARTICIPANT_CUSTOM },
+    { forceUniqid: 'Red', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pjsbv', templates: [{ title: 'Weather', _id: 'weather' }], pType: PARTICIPANT_CUSTOM },
+    { forceUniqid: 'Blue', icon: 'default_img/umpireDefault.png', roles: [], subscriptionId: 'k63pju7l', templates: [], pType: PARTICIPANT_CUSTOM }
   ] as ParticipantCustom[],
   uniqid: 'channel-k63pjit0'
 }

--- a/packages/mocks/cmd-week.mock.ts
+++ b/packages/mocks/cmd-week.mock.ts
@@ -11,7 +11,6 @@ const game: Wargame = {
           "channelType": "ChannelCustom",
           "participants": [
             {
-              "force": "White",
               "pType": "ParticipantCustom",
               "forceUniqid": "umpire",
               "roles": [],
@@ -24,7 +23,6 @@ const game: Wargame = {
               ]
             },
             {
-              "force": "CTF A",
               "pType": "ParticipantCustom",
               "forceUniqid": "Blue",
               "roles": [],
@@ -32,7 +30,6 @@ const game: Wargame = {
               "templates": []
             },
             {
-              "force": "CTF Y",
               "pType": "ParticipantCustom",
               "forceUniqid": "Red",
               "roles": [],
@@ -40,7 +37,6 @@ const game: Wargame = {
               "templates": []
             },
             {
-              "force": "White",
               "pType": "ParticipantCustom",
               "forceUniqid": "umpire",
               "roles": [
@@ -70,21 +66,18 @@ const game: Wargame = {
           "channelType": "ChannelChat",
           "participants": [
             {
-              "force": "White",
               "pType": "ParticipantChat",
               "forceUniqid": "umpire",
               "roles": [],
               "subscriptionId": "hyiju"
             },
             {
-              "force": "CTF B",
               "forceUniqid": "Blue",
               "roles": [],
               "subscriptionId": "jmpk",
               "pType": "ParticipantChat"
             },
             {
-              "force": "CTF Y",
               "forceUniqid": "Red",
               "roles": [],
               "subscriptionId": "kjoa",
@@ -98,14 +91,12 @@ const game: Wargame = {
           "channelType": "ChannelChat",
           "participants": [
             {
-              "force": "CTF A",
               "pType": "ParticipantChat",
               "forceUniqid": "Blue",
               "roles": [],
               "subscriptionId": "h034d"
             },
             {
-              "force": "White",
               "forceUniqid": "umpire",
               "roles": [
                 "rks5zfzd2"
@@ -121,7 +112,6 @@ const game: Wargame = {
           "channelType": "ChannelCustom",
           "participants": [
             {
-              "force": "CTF A",
               "forceUniqid": "Blue",
               "pType": "ParticipantCustom",
               "roles": [],
@@ -134,7 +124,6 @@ const game: Wargame = {
               ]
             },
             {
-              "force": "White",
               "pType": "ParticipantCustom",
               "forceUniqid": "umpire",
               "roles": [
@@ -151,14 +140,12 @@ const game: Wargame = {
           "channelType": "ChannelChat",
           "participants": [
             {
-              "force": "CTF Y",
               "forceUniqid": "Red",
               "roles": [],
               "subscriptionId": "7bayi",
               "pType": "ParticipantChat"
             },
             {
-              "force": "White",
               "forceUniqid": "umpire",
               "roles": [
                 "rkrlw6f5f"
@@ -174,7 +161,6 @@ const game: Wargame = {
           "channelType": "ChannelCustom",
           "participants": [
             {
-              "force": "Red",
               "forceUniqid": "Red",
               "roles": [],
               "pType": "ParticipantCustom",
@@ -187,7 +173,6 @@ const game: Wargame = {
               ]
             },
             {
-              "force": "White",
               "forceUniqid": "umpire",
               "pType": "ParticipantCustom",
               "roles": [
@@ -205,7 +190,6 @@ const game: Wargame = {
           "participants": [
             {
               "pType": "ParticipantCustom",
-              "force": "CTF B",
               "forceUniqid": "Blue",
               "roles": [],
               "subscriptionId": "etkkn",
@@ -217,7 +201,6 @@ const game: Wargame = {
               ]
             },
             {
-              "force": "White",
               "pType": "ParticipantCustom",
               "forceUniqid": "umpire",
               "roles": [
@@ -234,7 +217,6 @@ const game: Wargame = {
           "channelType": "ChannelCustom",
           "participants": [
             {
-              "force": "White",
               "pType": "ParticipantCustom",
               "forceUniqid": "umpire",
               "roles": [
@@ -244,7 +226,6 @@ const game: Wargame = {
               "templates": []
             },
             {
-              "force": "CTF Y",
               "pType": "ParticipantCustom",
               "forceUniqid": "Red",
               "roles": [],
@@ -264,7 +245,6 @@ const game: Wargame = {
           "channelType": "ChannelCustom",
           "participants": [
             {
-              "force": "White",
               "pType": "ParticipantCustom",
               "forceUniqid": "umpire",
               "roles": [
@@ -274,7 +254,6 @@ const game: Wargame = {
               "templates": []
             },
             {
-              "force": "CTF Y",
               "pType": "ParticipantCustom",
               "forceUniqid": "Red",
               "roles": [],
@@ -316,7 +295,6 @@ const game: Wargame = {
           },
           "participants": [
             {
-              "force": "White",
               "pType": "ParticipantMapping",
               "forceUniqid": "umpire",
               "controls": ["control-all:Green"],
@@ -324,7 +302,6 @@ const game: Wargame = {
               "subscriptionId": "zit48h"
             },
             {
-              "force": "CTF A",
               "pType": "ParticipantMapping",
               "forceUniqid": "Blue",
               "controls": ["control-all:Blue"],
@@ -333,7 +310,6 @@ const game: Wargame = {
             },
             {
               "pType": "ParticipantMapping",
-              "force": "CTF Y",
               "forceUniqid": "Red",
               "controls": ["control-all:Red"],
               "roles": ["rkr226f5e"],

--- a/packages/mocks/coa-channel-data-2.mock.ts
+++ b/packages/mocks/coa-channel-data-2.mock.ts
@@ -26,7 +26,6 @@ export const channelCollaborativeEditing2: ChannelCollab = {
       canCreate: true,
       viewUnreleasedVersions: true,
       permission: CollaborativePermission.CanSubmitForReview,
-      force: 'Blue',
       forceUniqid: 'Blue',
       roles: [],
       subscriptionId: 'oqoj'
@@ -36,7 +35,6 @@ export const channelCollaborativeEditing2: ChannelCollab = {
       canCreate: true,
       viewUnreleasedVersions: true,
       permission: CollaborativePermission.CanRelease,
-      force: 'Blue',
       forceUniqid: 'Blue',
       roles: [blueReleaseManager2.roleId],
       subscriptionId: 'oqoj2'
@@ -67,7 +65,6 @@ export const channelCollaborativeResponding2: ChannelCollab = {
       canCreate: true,
       viewUnreleasedVersions: false,
       permission: CollaborativePermission.CannotCollaborate,
-      force: 'Blue',
       forceUniqid: 'Blue',
       roles: [],
       subscriptionId: 'jvrn1'
@@ -77,7 +74,6 @@ export const channelCollaborativeResponding2: ChannelCollab = {
       canCreate: true,
       viewUnreleasedVersions: true,
       permission: CollaborativePermission.CanSubmitForReview,
-      force: 'EXCON',
       forceUniqid: 'Red',
       roles: [],
       subscriptionId: 'jvrn2'
@@ -87,7 +83,6 @@ export const channelCollaborativeResponding2: ChannelCollab = {
       canCreate: true,
       viewUnreleasedVersions: true,
       permission: CollaborativePermission.CanApprove,
-      force: 'White',
       forceUniqid: 'umpire',
       roles: [],
       subscriptionId: 'jvrn3'
@@ -97,7 +92,6 @@ export const channelCollaborativeResponding2: ChannelCollab = {
       canCreate: true,
       viewUnreleasedVersions: true,
       permission: CollaborativePermission.CanRelease,
-      force: 'White',
       forceUniqid: 'umpire',
       roles: [whiteReleaseMgr2.roleId],
       subscriptionId: 'jvrn4'

--- a/packages/mocks/game-channels-2.mock.ts
+++ b/packages/mocks/game-channels-2.mock.ts
@@ -10,27 +10,27 @@ const GameChannels2: Array<ChannelTypes> = [
     channelType: CHANNEL_CHAT,
     name: "Channel 16",
     participants: [
-      { pType: PARTICIPANT_CHAT, force: "White", forceUniqid: "umpire", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k63pjpfv" },
-      { pType: PARTICIPANT_CHAT, force: "Red", forceUniqid: "Red", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k63pjsbv" },
-      { pType: PARTICIPANT_CHAT, force: "Blue", forceUniqid: "Blue", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k63pju7l" }],
+      { pType: PARTICIPANT_CHAT, forceUniqid: "umpire", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k63pjpfv" },
+      { pType: PARTICIPANT_CHAT, forceUniqid: "Red", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k63pjsbv" },
+      { pType: PARTICIPANT_CHAT, forceUniqid: "Blue", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k63pju7l" }],
     uniqid: "channel-k63pjit0"
   },
   {
     channelType: CHANNEL_CUSTOM,
     name: "Blue Net",
     participants: [
-      { pType: PARTICIPANT_CUSTOM, force: "White", forceUniqid: "umpire", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k63pk0d3", templates: [] },
-      { pType: PARTICIPANT_CUSTOM, force: "Blue", forceUniqid: "Blue", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k63pk2o6", templates: [] }],
+      { pType: PARTICIPANT_CUSTOM, forceUniqid: "umpire", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k63pk0d3", templates: [] },
+      { pType: PARTICIPANT_CUSTOM, forceUniqid: "Blue", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k63pk2o6", templates: [] }],
     uniqid: "channel-k63pjvpb"
   },
   {
     channelType: CHANNEL_CUSTOM,
     name: "Mapping",
     participants: [
-      { pType: PARTICIPANT_CUSTOM, force: "White", forceUniqid: "umpire", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k53tifeo", templates: [] },
-      { pType: PARTICIPANT_CUSTOM, force: "Blue", forceUniqid: "Blue", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k53tij98", templates: [] },
-      { pType: PARTICIPANT_CUSTOM, force: "Red", forceUniqid: "Red", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k53tiqdf", templates: [] },
-      { pType: PARTICIPANT_CUSTOM, force: "Green", forceUniqid: "Green", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k53tivj5", templates: [] }],
+      { pType: PARTICIPANT_CUSTOM, forceUniqid: "umpire", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k53tifeo", templates: [] },
+      { pType: PARTICIPANT_CUSTOM, forceUniqid: "Blue", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k53tij98", templates: [] },
+      { pType: PARTICIPANT_CUSTOM, forceUniqid: "Red", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k53tiqdf", templates: [] },
+      { pType: PARTICIPANT_CUSTOM, forceUniqid: "Green", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k53tivj5", templates: [] }],
     uniqid: "channel-k53ti36p"
   },
   {
@@ -53,14 +53,14 @@ const GameChannels2: Array<ChannelTypes> = [
     },
     participants: [
       // all of white can collaborate, but not release
-      { pType: PARTICIPANT_COLLAB, canCreate: false, viewUnreleasedVersions: true, force: "White", permission: CollaborativePermission.CanApprove, forceUniqid: "umpire", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k63pds0d3" },
+      { pType: PARTICIPANT_COLLAB, canCreate: false, viewUnreleasedVersions: true, permission: CollaborativePermission.CanApprove, forceUniqid: "umpire", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k63pds0d3" },
       // white RFI Mgr can release
       {
-        pType: PARTICIPANT_COLLAB, canCreate: false, viewUnreleasedVersions: true, force: "White", permission: CollaborativePermission.CanRelease, forceUniqid: "umpire", icon: "default_img/umpireDefault.png", roles: [whiteRFI.roleId], subscriptionId: "k63pk0d3"
+        pType: PARTICIPANT_COLLAB, canCreate: false, viewUnreleasedVersions: true, permission: CollaborativePermission.CanRelease, forceUniqid: "umpire", icon: "default_img/umpireDefault.png", roles: [whiteRFI.roleId], subscriptionId: "k63pk0d3"
       },
       // blue force can just send RFO
       {
-        pType: PARTICIPANT_COLLAB, canCreate: true, viewUnreleasedVersions: false, force: "Blue", permission: CollaborativePermission.CannotCollaborate, forceUniqid: "Blue", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k62342o6"
+        pType: PARTICIPANT_COLLAB, canCreate: true, viewUnreleasedVersions: false, permission: CollaborativePermission.CannotCollaborate, forceUniqid: "Blue", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k62342o6"
       }],
     uniqid: "channel-BlueRFI"
   },
@@ -79,11 +79,11 @@ const GameChannels2: Array<ChannelTypes> = [
     participants: [
       // all of blue can collaborate
       {
-        pType: PARTICIPANT_COLLAB, canCreate: true, viewUnreleasedVersions: true, force: "Blue", permission: CollaborativePermission.CanSubmitForReview, forceUniqid: "Blue", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k63pk2o7"
+        pType: PARTICIPANT_COLLAB, canCreate: true, viewUnreleasedVersions: true, permission: CollaborativePermission.CanSubmitForReview, forceUniqid: "Blue", icon: "default_img/umpireDefault.png", roles: [], subscriptionId: "k63pk2o7"
       },
       // Blue CO can release 
       {
-        pType: PARTICIPANT_COLLAB, canCreate: true, viewUnreleasedVersions: true, force: "Blue", permission: CollaborativePermission.CanRelease, forceUniqid: "Blue", icon: "default_img/umpireDefault.png", roles: [blueCO.roleId], subscriptionId: "k63pk2o7"
+        pType: PARTICIPANT_COLLAB, canCreate: true, viewUnreleasedVersions: true, permission: CollaborativePermission.CanRelease, forceUniqid: "Blue", icon: "default_img/umpireDefault.png", roles: [blueCO.roleId], subscriptionId: "k63pk2o7"
       }],
     uniqid: "channel-BlueCOA"
   }

--- a/packages/mocks/p9.mock.ts
+++ b/packages/mocks/p9.mock.ts
@@ -362,7 +362,7 @@ const game: Wargame = {
               perceptions: [
                 {
                   by: 'F-Blue',
-                  force: 'Green',
+                  force: 'F-Green',
                   name: 'SHU’AI',
                   typeId: 'id-fisher'
                 }
@@ -416,7 +416,7 @@ const game: Wargame = {
               perceptions: [
                 {
                   by: 'F-Blue',
-                  force: 'Green',
+                  force: 'F-Green',
                   name: 'OSAKA',
                   typeId: 'id-merchant'
                 }
@@ -432,13 +432,13 @@ const game: Wargame = {
               perceptions: [
                 {
                   by: 'F-Blue',
-                  force: 'Green',
+                  force: 'F-Green',
                   name: 'ARUNA 12',
                   typeId: 'id-merchant'
                 },
                 {
                   by: 'F-Red',
-                  force: 'Green',
+                  force: 'F-Green',
                   name: 'BARLAY',
                   typeId: 'id-merchant'
                 }
@@ -457,7 +457,7 @@ const game: Wargame = {
               perceptions: [
                 {
                   by: 'F-Blue',
-                  force: 'Green',
+                  force: 'F-Green',
                   name: 'JALIBUT',
                   typeId: 'id-merchant'
                 }
@@ -472,7 +472,7 @@ const game: Wargame = {
               perceptions: [
                 {
                   by: 'F-Blue',
-                  force: 'Green',
+                  force: 'F-Green',
                   typeId: 'id-merchant'
                 }
               ],
@@ -491,13 +491,13 @@ const game: Wargame = {
               perceptions: [
                 {
                   by: 'F-Blue',
-                  force: 'Green',
+                  force: 'F-Green',
                   name: 'BOUM 3',
                   typeId: 'id-merchant'
                 },
                 {
                   by: 'F-Red',
-                  force: 'Green',
+                  force: 'F-Green',
                   name: 'BOUM 3',
                   typeId: 'id-merchant'
                 }

--- a/packages/mocks/p9.mock.ts
+++ b/packages/mocks/p9.mock.ts
@@ -11,7 +11,6 @@ const game: Wargame = {
           channelType: 'ChannelPlanning',
           participants: [
             {
-              force: 'CTF A',
               forceUniqid: 'F-Blue',
               pType: 'ParticipantPlanning',
               roles: [],
@@ -24,7 +23,6 @@ const game: Wargame = {
               ]
             },
             {
-              force: 'F-Red',
               forceUniqid: 'F-Red',
               pType: 'ParticipantPlanning',
               roles: [],
@@ -37,7 +35,6 @@ const game: Wargame = {
               ]
             },
             {
-              force: 'White',
               pType: 'ParticipantPlanning',
               forceUniqid: 'umpire',
               roles: ['rkrlw6f5f'],
@@ -52,14 +49,12 @@ const game: Wargame = {
           channelType: 'ChannelChat',
           participants: [
             {
-              force: 'CTF Y',
               forceUniqid: 'F-Red',
               roles: [],
               subscriptionId: '7bayi',
               pType: 'ParticipantChat'
             },
             {
-              force: 'White',
               forceUniqid: 'umpire',
               roles: ['rkrlw6f5f'],
               subscriptionId: 'h2my2k',
@@ -74,7 +69,6 @@ const game: Wargame = {
           participants: [
             {
               pType: 'ParticipantCustom',
-              force: 'CTF B',
               forceUniqid: 'F-Blue',
               roles: [],
               subscriptionId: 'etkkn',
@@ -86,7 +80,6 @@ const game: Wargame = {
               ]
             },
             {
-              force: 'White',
               pType: 'ParticipantCustom',
               forceUniqid: 'umpire',
               roles: ['rkrlw6f5f'],
@@ -101,7 +94,6 @@ const game: Wargame = {
           channelType: 'ChannelCustom',
           participants: [
             {
-              force: 'White',
               pType: 'ParticipantCustom',
               forceUniqid: 'umpire',
               roles: ['rks5zfzd5'],
@@ -109,7 +101,6 @@ const game: Wargame = {
               templates: []
             },
             {
-              force: 'CTF Y',
               pType: 'ParticipantCustom',
               forceUniqid: 'F-Red',
               roles: [],

--- a/packages/mocks/wargame-exported.mock.ts
+++ b/packages/mocks/wargame-exported.mock.ts
@@ -69,7 +69,6 @@ const game: Wargame = {
           channelType: 'ChannelCustom',
           participants: [
             {
-              force: 'White',
               forceUniqid: 'umpire',
               icon: 'images/default_img/umpireDefault.png',
               roles: [],
@@ -103,7 +102,6 @@ const game: Wargame = {
           channelType: 'ChannelCustom',
           participants: [
             {
-              force: 'White',
               forceUniqid: 'umpire',
               icon: 'images/default_img/umpireDefault.png',
               roles: [],
@@ -128,7 +126,6 @@ const game: Wargame = {
           channelType: 'ChannelCustom',
           participants: [
             {
-              force: 'White',
               forceUniqid: 'umpire',
               icon: 'images/default_img/umpireDefault.png',
               roles: [],

--- a/packages/mocks/watu-playtest-mock.ts
+++ b/packages/mocks/watu-playtest-mock.ts
@@ -61,42 +61,36 @@ const wargame: Wargame = {
                     "channelType": "ChannelChat",
                     "participants": [
                         {
-                            "force": "White",
                             "forceUniqid": "umpire",
                             "roles": [],
                             "subscriptionId": "nci8",
                             "pType": "ParticipantChat"
                         },
                         {
-                            "force": "B1",
                             "forceUniqid": "force-b1",
                             "roles": [],
                             "subscriptionId": "119o",
                             "pType": "ParticipantChat"
                         },
                         {
-                            "force": "B2",
                             "forceUniqid": "force-b2",
                             "roles": [],
                             "subscriptionId": "y8e5h",
                             "pType": "ParticipantChat"
                         },
                         {
-                            "force": "B3",
                             "forceUniqid": "force-b3",
                             "roles": [],
                             "subscriptionId": "rrcif",
                             "pType": "ParticipantChat"
                         },
                         {
-                            "force": "B4",
                             "forceUniqid": "force-b4",
                             "roles": [],
                             "subscriptionId": "njra",
                             "pType": "ParticipantChat"
                         },
                         {
-                            "force": "B5",
                             "forceUniqid": "force-b5",
                             "roles": [],
                             "subscriptionId": "ovmn",
@@ -110,21 +104,18 @@ const wargame: Wargame = {
                     "channelType": "ChannelChat",
                     "participants": [
                         {
-                            "force": "White",
                             "forceUniqid": "umpire",
                             "roles": [],
                             "subscriptionId": "dfyw8",
                             "pType": "ParticipantChat"
                         },
                         {
-                            "force": "R1",
                             "forceUniqid": "force-r1",
                             "roles": [],
                             "subscriptionId": "ttgbg",
                             "pType": "ParticipantChat"
                         },
                         {
-                            "force": "R2",
                             "forceUniqid": "force-r2",
                             "roles": [],
                             "subscriptionId": "08iqa",
@@ -138,42 +129,36 @@ const wargame: Wargame = {
                     "channelType": "ChannelChat",
                     "participants": [
                         {
-                            "force": "White",
                             "forceUniqid": "umpire",
                             "roles": [],
                             "subscriptionId": "epplc",
                             "pType": "ParticipantChat"
                         },
                         {
-                            "force": "B1",
                             "forceUniqid": "force-b1",
                             "roles": [],
                             "subscriptionId": "eca6s",
                             "pType": "ParticipantChat"
                         },
                         {
-                            "force": "B2",
                             "forceUniqid": "force-b2",
                             "roles": [],
                             "subscriptionId": "1i72a",
                             "pType": "ParticipantChat"
                         },
                         {
-                            "force": "B3",
                             "forceUniqid": "force-b3",
                             "roles": [],
                             "subscriptionId": "m87ny",
                             "pType": "ParticipantChat"
                         },
                         {
-                            "force": "B4",
                             "forceUniqid": "force-b4",
                             "roles": [],
                             "subscriptionId": "90mjl",
                             "pType": "ParticipantChat"
                         },
                         {
-                            "force": "B5",
                             "forceUniqid": "force-b5",
                             "roles": [],
                             "subscriptionId": "2v4wa",
@@ -187,7 +172,6 @@ const wargame: Wargame = {
                     "channelType": "mapping",
                     "participants": [
                         {
-                            "force": "White",
                             "forceUniqid": "umpire",
                             "roles": [
                                 "pl63jl7so"
@@ -199,7 +183,6 @@ const wargame: Wargame = {
                             ]
                         },
                         {
-                            "force": "B1",
                             "forceUniqid": "force-b1",
                             "roles": [
                                 "pl65060rb"
@@ -211,7 +194,6 @@ const wargame: Wargame = {
                             ]
                         },
                         {
-                            "force": "B2",
                             "forceUniqid": "force-b2",
                             "roles": [
                                 "rl6506vlp"
@@ -223,7 +205,6 @@ const wargame: Wargame = {
                             ]
                         },
                         {
-                            "force": "B3",
                             "forceUniqid": "force-b3",
                             "roles": [
                                 "rl65088ad"
@@ -235,7 +216,6 @@ const wargame: Wargame = {
                             ]
                         },
                         {
-                            "force": "B4",
                             "forceUniqid": "force-b4",
                             "roles": [
                                 "rl6509vwn"
@@ -247,7 +227,6 @@ const wargame: Wargame = {
                             ]
                         },
                         {
-                            "force": "B5",
                             "forceUniqid": "force-b5",
                             "roles": [
                                 "rl650arbo"
@@ -259,7 +238,6 @@ const wargame: Wargame = {
                             ]
                         },
                         {
-                            "force": "R1",
                             "forceUniqid": "force-r1",
                             "roles": [
                                 "rl650chc3"
@@ -271,7 +249,6 @@ const wargame: Wargame = {
                             ]
                         },
                         {
-                            "force": "R2",
                             "forceUniqid": "force-r2",
                             "roles": [
                                 "rl650dmne"
@@ -306,7 +283,6 @@ const wargame: Wargame = {
                     "name": "White Comms",
                     "participants": [
                         {
-                            "force": "White",
                             "forceUniqid": "umpire",
                             "pType": "ParticipantChat",
                             "roles": [],

--- a/packages/mocks/watu-wargame-mock.ts
+++ b/packages/mocks/watu-wargame-mock.ts
@@ -11,7 +11,6 @@ const wargame: Wargame = {
                     "channelType": "ChannelCustom",
                     "participants": [
                         {
-                            "force": "White",
                             "forceUniqid": "umpire",
                             "roles": [],
                             "subscriptionId": "8qsze9",
@@ -19,7 +18,6 @@ const wargame: Wargame = {
                             "pType": "ParticipantCustom"
                         },
                         {
-                            "force": "CTF B",
                             "forceUniqid": "Blue-1",
                             "roles": [],
                             "subscriptionId": "hzrzp",
@@ -27,7 +25,6 @@ const wargame: Wargame = {
                             "pType": "ParticipantCustom"
                         },
                         {
-                            "force": "CTF Y",
                             "forceUniqid": "Red-1",
                             "roles": [],
                             "subscriptionId": "icrx",
@@ -56,14 +53,12 @@ const wargame: Wargame = {
                     },
                     "participants": [
                         {
-                            "force": "White",
                             "pType": "ParticipantMapping",
                             "forceUniqid": "umpire",
                             "roles": [],
                             "subscriptionId": "white-view"
                         },
                         {
-                            "force": "White",
                             "pType": "ParticipantMapping",
                             "forceUniqid": "umpire",
                             "roles": ["umpire-GC"],
@@ -71,7 +66,6 @@ const wargame: Wargame = {
                             "subscriptionId": "white-control-green-all"
                         },
                         {
-                            "force": "White",
                             "pType": "ParticipantMapping",
                             "forceUniqid": "umpire",
                             "roles": ["umpire-blue-hq"],
@@ -79,14 +73,12 @@ const wargame: Wargame = {
                             "subscriptionId": "white-control-green-asset"
                         },
                         {
-                            "force": "CTF B",
                             "forceUniqid": "Blue-1",
                             "roles": [],
                             "subscriptionId": "w9lmf",
                             "pType": "ParticipantMapping"
                         },
                         {
-                            "force": "CTF B",
                             "forceUniqid": "Blue-1",
                             "roles": ["nortCO"],
                             "subscriptionId": "nortCO-control",
@@ -94,7 +86,6 @@ const wargame: Wargame = {
                             "controls": ["nortID"]
                         },
                         {
-                            "force": "CTF B",
                             "forceUniqid": "Blue-1",
                             "roles": ["blueCO"],
                             "subscriptionId": "blue-CO-control-all",
@@ -102,7 +93,6 @@ const wargame: Wargame = {
                             "controls": ["control-all:Blue-1"]
                         },
                         {
-                            "force": "CTF Y",
                             "forceUniqid": "Red-1",
                             "roles": ["red-CO"],
                             "subscriptionId": "red-co-all",
@@ -110,7 +100,6 @@ const wargame: Wargame = {
                             "pType": "ParticipantMapping"
                         },
                         {
-                            "force": "CTF Y",
                             "forceUniqid": "Red-1",
                             "roles": [],
                             "subscriptionId": "red-viewers",


### PR DESCRIPTION
In channel definitions we had force-name AND force-id.

This was causing some confusion, and making testing difficult.  It would also have been fragile to forces being renamed.

So, remove the `participant.force` field.

(also fix some perceived force names in `p9.mock`)