### PR TITLE
Hotfix planning channel

### DIFF
--- a/packages/client/src/Components/PlanningChannel.tsx
+++ b/packages/client/src/Components/PlanningChannel.tsx
@@ -49,6 +49,7 @@ const PlanningChannel: React.FC<{ channelId: string }> = ({ channelId }) => {
   // what data is stored in the the channels dictionary
   const messages = state.channels[channelId].messages as any
 
+  // drop the turn markers
   const planningMessages = messages.filter((msg: CoreMessage) => msg.messageType !== INFO_MESSAGE_CLIPPED)
 
   const onRead = (detail: MessagePlanning): void => {

--- a/packages/client/src/Components/PlanningChannel.tsx
+++ b/packages/client/src/Components/PlanningChannel.tsx
@@ -1,6 +1,8 @@
 import { makeStyles } from '@material-ui/styles'
 import { SupportPanel } from '@serge/components'
+import { INFO_MESSAGE_CLIPPED } from '@serge/config'
 import { ChannelPlanning, MessageChannel, MessagePlanning } from '@serge/custom-types'
+import { CoreMessage } from '@serge/custom-types/message'
 import '@serge/themes/App.scss'
 import cx from 'classnames'
 import React, { useEffect, useState } from 'react'
@@ -47,6 +49,8 @@ const PlanningChannel: React.FC<{ channelId: string }> = ({ channelId }) => {
   // what data is stored in the the channels dictionary
   const messages = state.channels[channelId].messages as any
 
+  const planningMessages = messages.filter((msg: CoreMessage) => msg.messageType !== INFO_MESSAGE_CLIPPED)
+
   const onRead = (detail: MessagePlanning): void => {
     dispatch(openMessage(channelId, detail as any as MessageChannel))
   }
@@ -67,7 +71,7 @@ const PlanningChannel: React.FC<{ channelId: string }> = ({ channelId }) => {
         platformTypes={platformTypes}
         forceNames={forceNames}
         hideForcesInChannel={hideForcesInChannel}
-        messages={messages}
+        messages={planningMessages}
         selectedForce={selectedForce.uniqid}
         selectedRole={selectedRole}
         forces={allForces}

--- a/packages/client/src/Components/PlanningChannel.tsx
+++ b/packages/client/src/Components/PlanningChannel.tsx
@@ -22,7 +22,6 @@ const PlanningChannel: React.FC<{ channelId: string }> = ({ channelId }) => {
   const dispatch = usePlayerUiDispatch()
   const channelUI = state.channels[channelId]
   const channelPlanning = channelUI.cData as ChannelPlanning
-  console.log('rendering planning channel', channelPlanning.name)
   const [channelTabClass, setChannelTabClass] = useState<string>('')
   const { allForces, currentWargame, selectedForce, selectedRole } = state
   if (selectedForce === undefined) throw new Error('selectedForce is undefined')

--- a/packages/components/src/local/organisms/planning-messages-list/index.tsx
+++ b/packages/components/src/local/organisms/planning-messages-list/index.tsx
@@ -27,7 +27,7 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({ messages, templates,
       }
     })
     setRows(dataTable)
-  }, [])
+  }, [messages])
 
   // fix unit-test for MaterialTable
   const jestWorkerId = process.env.JEST_WORKER_ID


### PR DESCRIPTION
There's an emergent runtime bug.  The PlanningChannel component assumed it only got real messages.

But, yesterday's "fix" for turn markers mean the channel also received information markers - giving this error:
![image](https://user-images.githubusercontent.com/1108513/189409035-812b2c86-b32d-48bb-b50d-454ccb9d163f.png)
