### PR TITLE
Hotfix pass template to json editor

### DIFF
--- a/packages/components/src/local/mapping/helpers/gen-test-data.ts
+++ b/packages/components/src/local/mapping/helpers/gen-test-data.ts
@@ -27,7 +27,7 @@ const randomPointInPoly = (polygon: L.Polygon): any => {
   }
 }
 
-const doesIt = () => {
+const doesIt = (): boolean => {
   const probDetect = Math.floor(Math.random() * 100)
   return probDetect > 40
 }

--- a/packages/components/src/local/molecules/collab-message-detail/index.tsx
+++ b/packages/components/src/local/molecules/collab-message-detail/index.tsx
@@ -354,6 +354,19 @@ export const CollabMessageDetail: React.FC<Props> = ({
       })
     })
 
+    // sort out the template for the JSON editor
+    let templateId: string | undefined
+    if (isResponse) {
+      if (canSeeResponse) {
+        templateId = channelCollab.responseTemplate?._id
+      } else {
+        templateId = channelCollab.newMessageTemplate?._id
+      }
+    } else {
+      templateId = channelCollab.newMessageTemplate?._id
+    }
+    const template = templateId && templates[templateId]
+
     return (
       <>
         <div className={styles.main}>
@@ -377,20 +390,18 @@ export const CollabMessageDetail: React.FC<Props> = ({
             }
             {
               isResponse && <JsonEditor
-                messageTemplates={templates}
                 messageContent={message.message}
                 messageId={`${message._id}_${message.message.Reference}`}
-                template={channelCollab.newMessageTemplate?._id || ''}
+                template={template}
                 storeNewValue={notHappeningHandler}
                 disabled={true}
                 gameDate={gameDate}
               />
             }
             {isResponse && canSeeResponse && <JsonEditor
-              messageTemplates={templates}
               messageId={`${message._id}_${message.message.Reference}`}
               messageContent={collaboration.response || {}}
-              template={channelCollab.responseTemplate?._id || ''}
+              template={template}
               storeNewValue={responseHandler}
               disabled={!formIsEditable}
               title={'Response'}
@@ -398,8 +409,7 @@ export const CollabMessageDetail: React.FC<Props> = ({
             />
             }
             {!isResponse && <JsonEditor
-              messageTemplates={templates}
-              template={channelCollab.newMessageTemplate?._id || ''}
+              template={template}
               messageId={`${message._id}_${message.message.Reference}`}
               messageContent={message.message}
               storeNewValue={newMessageHandler}

--- a/packages/components/src/local/molecules/json-editor/__snapshots__/index.spec.tsx.snap
+++ b/packages/components/src/local/molecules/json-editor/__snapshots__/index.spec.tsx.snap
@@ -12,6 +12,5 @@ exports[`ChannelMessageDetail: renders correctly 1`] = `
   }
 >
   Schema not found for 
-  CustomMessage
 </span>
 `;

--- a/packages/components/src/local/molecules/json-editor/index.spec.tsx
+++ b/packages/components/src/local/molecules/json-editor/index.spec.tsx
@@ -5,13 +5,13 @@ import JsonEditor from './index'
 
 import { MessageTemplatesMockByKey, messageDataCollaborativeEditing, WargameMock } from '@serge/mocks'
 const message = messageDataCollaborativeEditing[2]
+const template = MessageTemplatesMockByKey[message.messageType]
 describe('ChannelMessageDetail:', () => {
   it('renders correctly', () => {
     const tree = renderer
       .create(<JsonEditor
-        messageTemplates={MessageTemplatesMockByKey}
         messageContent={message.message}
-        template={message.messageType}
+        template={template}
         messageId={`${message._id}_${message.message.Reference}`}
         disabled={true}
         gameDate={WargameMock.data.overview.gameDate}

--- a/packages/components/src/local/molecules/json-editor/index.stories.tsx
+++ b/packages/components/src/local/molecules/json-editor/index.stories.tsx
@@ -35,28 +35,28 @@ const storeNewValue = (value: { [property: string]: any }): void => {
   console.log('store data', value)
 }
 
-const Template: Story<Props> = ({ messageTemplates, messageId, disabled, template, messageContent }) => {
+const template = MessageTemplatesMockByKey[messageDataCollaborativeEditing[0].details.messageType]
+
+const Template: Story<Props> = ({ messageId, disabled, template, messageContent }) => {
   return (
-    <JsonEditor storeNewValue={storeNewValue} template={template} messageId={messageId} messageContent={messageContent} messageTemplates={messageTemplates} disabled={disabled} gameDate={WargameMock.data.overview.gameDate} />
+    <JsonEditor storeNewValue={storeNewValue} template={template} messageId={messageId} messageContent={messageContent} disabled={disabled} gameDate={WargameMock.data.overview.gameDate} />
   )
 }
 
 export const Standard = Template.bind({})
 Standard.args = {
   messageContent: messageDataCollaborativeEditing[0].message,
-  messageTemplates: MessageTemplatesMockByKey,
   messageId: 'id_1',
-  template: 'k16eedkk',
+  template: template,
   disabled: false,
   gameDate: WargameMock.data.overview.gameDate
 }
 
 export const Response = Template.bind({})
 Response.args = {
-  template: 'k16eedkj',
+  template: messageDataCollaborativeResponding[0].details.messageType,
   messageContent: messageDataCollaborativeResponding[0].message,
   messageId: 'id_2ß',
-  messageTemplates: MessageTemplatesMockByKey,
   disabled: false,
   gameDate: WargameMock.data.overview.gameDate
 }

--- a/packages/components/src/local/molecules/json-editor/index.tsx
+++ b/packages/components/src/local/molecules/json-editor/index.tsx
@@ -15,11 +15,11 @@ import { expiredStorage } from '@serge/config'
 const keydowListenFor: string[] = ['TEXTAREA', 'INPUT']
 
 /* Render component */
-export const JsonEditor: React.FC<Props> = ({ messageTemplates, messageId, messageContent, title, template, storeNewValue, disabled = false, expandHeight = true, gameDate, disableArrayToolsWithEditor = true }) => {
+export const JsonEditor: React.FC<Props> = ({ messageId, messageContent, title, template, storeNewValue, disabled = false, expandHeight = true, gameDate, disableArrayToolsWithEditor = true }) => {
   const jsonEditorRef = useRef<HTMLDivElement>(null)
   const [editor, setEditor] = useState<Editor | null>(null)
 
-  if (!messageTemplates[template]) {
+  if (!template) {
     const styles = {
       color: '#f00',
       background: '#ff0',
@@ -41,7 +41,7 @@ export const JsonEditor: React.FC<Props> = ({ messageTemplates, messageId, messa
     const jsonEditorConfig = disabled
       ? { disableArrayReOrder: true, disableArrayAdd: true, disableArrayDelete: true }
       : { disableArrayReOrder: false, disableArrayAdd: false, disableArrayDelete: false }
-    const modSchema = configDateTimeLocal(messageTemplates[template].details, gameDate)
+    const modSchema = configDateTimeLocal(template.details, gameDate)
 
     // if a title was supplied, replace the title in the schema
     const schemaWithTitle = title ? { ...modSchema, title: title } : modSchema

--- a/packages/components/src/local/molecules/json-editor/types/props.d.ts
+++ b/packages/components/src/local/molecules/json-editor/types/props.d.ts
@@ -17,15 +17,11 @@ export default interface Props {
   /**
    * template ID
    */
-  template: string
+  template: TemplateBody
   /**
    * title to display above the form
    */
   title?: string
-  /**
-   * dictionary of templates, indexed by template name
-   */
-  messageTemplates: TemplateBodysByKey
   /**
    * whether the form is editable (disable for read-only view)
    */

--- a/packages/components/src/local/molecules/json-editor/types/props.d.ts
+++ b/packages/components/src/local/molecules/json-editor/types/props.d.ts
@@ -1,4 +1,4 @@
-import { MessageCustom, MessageStructure, TemplateBodysByKey } from '@serge/custom-types'
+import { MessageCustom, MessageStructure } from '@serge/custom-types'
 
 export default interface Props {
   onChange?: (nextMessage: MessageCustom) => void

--- a/packages/components/src/local/organisms/orders/index.tsx
+++ b/packages/components/src/local/organisms/orders/index.tsx
@@ -1,4 +1,4 @@
-import { MessagePlanning, TemplateBody } from '@serge/custom-types'
+import { MessagePlanning } from '@serge/custom-types'
 import MaterialTable from 'material-table'
 import React from 'react'
 import JsonEditor from '../../molecules/json-editor'
@@ -24,11 +24,14 @@ export const Orders: React.FC<PropTypes> = ({ messages, columns, rows, title, te
       if (!message) {
         console.error('message not found, id:', rowData.id)
       }
+      const template = templatesByKey[message.details.messageType]
+      if (!template) {
+        console.error('template not found, id:', message.details.messageType)
+      }
       return message && <JsonEditor
-        messageTemplates={templatesByKey}
         messageContent={message}
         messageId={rowData.id}
-        template={templates.find((value: TemplateBody) => value.title === message.details.messageType)._id}
+        template={template}
         disabled={true}
         gameDate={gameDate}
       />


### PR DESCRIPTION
Refactor `<JsonEditor>` to just receive a template, not a dictionary of templates plus an id value.