### PR TITLE
Hotfix display orders

### DIFF
--- a/packages/components/src/local/organisms/map-planning-orders/index.spec.tsx
+++ b/packages/components/src/local/organisms/map-planning-orders/index.spec.tsx
@@ -8,6 +8,21 @@ jest.mock('react-leaflet-v4', () => ({
   GeoJSON: (): React.ReactElement => <></>
 }))
 
+jest.mock('leaflet', () => ({
+  ...jest.requireActual('leaflet'),
+  Symbol: {
+    arrowHead: jest.fn()
+  }
+}))
+
+jest.mock('react-leaflet-v4', () => ({
+  useMap: (): jest.Mock => jest.fn()
+}))
+
+jest.mock('react-leaflet-geoman-v2', () => ({
+  GeomanControls: (): React.ReactElement => <></>
+}))
+
 describe('Planning Force component: ', () => {
   it('renders component correctly', () => {
     const tree = renderer

--- a/packages/components/src/local/organisms/map-planning-orders/index.tsx
+++ b/packages/components/src/local/organisms/map-planning-orders/index.tsx
@@ -21,8 +21,6 @@ const localFindActivity = (activities: PlanningActivity[], uniqid: PlanningActiv
 export const MapPlanningOrders: React.FC<PropTypes> = ({ orders, activities, forceColor }) => {
   const [orderGeometries, setOrderGeometries] = useState<GeoJsonObject | undefined>()
 
-  console.log('orders', orders)
-
   const geojsonMarkerOptions = {
     radius: 20,
     fillColor: '#ff7800',
@@ -108,8 +106,6 @@ export const MapPlanningOrders: React.FC<PropTypes> = ({ orders, activities, for
       console.log(timings)
     }
   }, [orders])
-
-  console.log('order geometries', orderGeometries)
 
   return <>
     {

--- a/packages/components/src/local/organisms/map-planning-orders/index.tsx
+++ b/packages/components/src/local/organisms/map-planning-orders/index.tsx
@@ -86,12 +86,10 @@ export const MapPlanningOrders: React.FC<PropTypes> = ({ orders, activities, for
   }, [orders])
 
   return <>
-    {
-      orderGeometries &&
+    { orderGeometries && orderGeometries.length > 0 &&
       <LayerGroup key={'orders'}>
         { orderGeometries }
-      </LayerGroup>
-    }
+      </LayerGroup> }
   </>
 }
 

--- a/packages/components/src/local/organisms/map-planning-orders/index.tsx
+++ b/packages/components/src/local/organisms/map-planning-orders/index.tsx
@@ -65,7 +65,7 @@ export const MapPlanningOrders: React.FC<PropTypes> = ({ orders, activities, for
           if (activity && activity.color) {
             color = activity.color
           }
-          return shapeFor(feature, color, feature.properties ? feature.properties.name : 'unknown', storeRef)
+          return shapeFor(feature, color, feature.properties.name || 'unknown', storeRef)
         } else {
           return <></>
         }

--- a/packages/components/src/local/organisms/map-planning-orders/index.tsx
+++ b/packages/components/src/local/organisms/map-planning-orders/index.tsx
@@ -42,7 +42,7 @@ export const MapPlanningOrders: React.FC<PropTypes> = ({ orders, activities, for
                 res.properties.name = geometry.name
               }
             } else {
-              console.warn('failed to find activity for', act.uniqid, activities)
+              console.warn('failed to find activity for', act.uniqid)
             }
             return res
           })

--- a/packages/components/src/local/organisms/map-planning-orders/index.tsx
+++ b/packages/components/src/local/organisms/map-planning-orders/index.tsx
@@ -1,5 +1,6 @@
 
 import { MessagePlanning, PlannedActivityGeometry, PlanningActivity, PlanningActivityGeometry } from '@serge/custom-types'
+import { GeoJsonObject } from 'geojson'
 import { circleMarker, LatLng, Layer, PathOptions, StyleFunction } from 'leaflet'
 import _ from 'lodash'
 import React, { useEffect, useState } from 'react'
@@ -18,7 +19,9 @@ const localFindActivity = (activities: PlanningActivity[], uniqid: PlanningActiv
 }
 
 export const MapPlanningOrders: React.FC<PropTypes> = ({ orders, activities, forceColor }) => {
-  const [orderGeometries, setOrderGeometries] = useState<GeoJSON.Feature[] | undefined>()
+  const [orderGeometries, setOrderGeometries] = useState<GeoJsonObject | undefined>()
+
+  console.log('orders', orders)
 
   const geojsonMarkerOptions = {
     radius: 20,
@@ -88,7 +91,11 @@ export const MapPlanningOrders: React.FC<PropTypes> = ({ orders, activities, for
         }
       })
       const flatGeom = _.flatten(geometries)
-      setOrderGeometries(flatGeom)
+      const geojson = {
+        type: 'FeatureCollection',
+        features: flatGeom
+      }
+      setOrderGeometries(geojson as GeoJsonObject)
     }
   }, [orders])
 
@@ -102,11 +109,13 @@ export const MapPlanningOrders: React.FC<PropTypes> = ({ orders, activities, for
     }
   }, [orders])
 
+  console.log('order geometries', orderGeometries)
+
   return <>
     {
       orderGeometries &&
       <LayerGroup key={'orders'}>
-        <GeoJSON style={styleFor} pointToLayer={pointToLayer} onEachFeature={onEachFeature} data={{ ...orderGeometries, type: 'Feature' }} />
+        <GeoJSON style={styleFor} pointToLayer={pointToLayer} onEachFeature={onEachFeature} data={{ ...orderGeometries, type: 'FeatureCollection' }} />
       </LayerGroup>
     }
   </>

--- a/packages/components/src/local/organisms/map-planning-orders/index.tsx
+++ b/packages/components/src/local/organisms/map-planning-orders/index.tsx
@@ -1,10 +1,11 @@
 
 import { MessagePlanning, PlannedActivityGeometry, PlanningActivity, PlanningActivityGeometry } from '@serge/custom-types'
-import { GeoJsonObject } from 'geojson'
-import { circleMarker, LatLng, Layer, PathOptions, StyleFunction } from 'leaflet'
+import { Feature } from 'geojson'
+import { Layer } from 'leaflet'
 import _ from 'lodash'
 import React, { useEffect, useState } from 'react'
-import { GeoJSON, LayerGroup } from 'react-leaflet-v4'
+import { LayerGroup } from 'react-leaflet-v4'
+import { shapeFor } from '../planning-channel/helpers/SharedOrderRenderer'
 import PropTypes from './types/props'
 
 const localFindActivity = (activities: PlanningActivity[], uniqid: PlanningActivityGeometry['uniqid']): PlanningActivity | undefined => {
@@ -19,53 +20,13 @@ const localFindActivity = (activities: PlanningActivity[], uniqid: PlanningActiv
 }
 
 export const MapPlanningOrders: React.FC<PropTypes> = ({ orders, activities, forceColor }) => {
-  const [orderGeometries, setOrderGeometries] = useState<GeoJsonObject | undefined>()
-
-  const geojsonMarkerOptions = {
-    radius: 20,
-    fillColor: '#ff7800',
-    color: '#0f0',
-    weight: 1,
-    opacity: 1,
-    fillOpacity: 0.8
-  }
-
-  const pointToLayer = (_feature: GeoJSON.Feature<any>, latlng: LatLng): Layer => {
-    return circleMarker(latlng, geojsonMarkerOptions)
-  }
-
-  /** orders definitions can specify the color to use.  If there is one, use it.
-   * else use the force color
-   */
-  const styleFor: StyleFunction<any> = (feature?: GeoJSON.Feature<any>): PathOptions => {
-    const featureId = feature && feature.properties && feature.properties.uniqid
-    if (featureId && activities && activities.length) {
-      const activity = localFindActivity(activities, featureId)
-      if (activity) {
-        const color = activity.color
-        return {
-          color: color,
-          fillColor: color,
-          className: 'leaflet-default-icon-path'
-        }
-      }
-    }
-    return {
-      color: forceColor || '#f00'
-    }
-  }
-
-  const onEachFeature = (feature: GeoJSON.Feature, layer: Layer): any => {
-    // put the activity name into the popup for the feature
-    if (feature && feature.properties && feature.properties.name) {
-      layer.bindPopup(feature.properties.name)
-    }
-  }
+  const [orderGeometries, setOrderGeometries] = useState<React.ReactElement[]>([])
+  const [layersToDelete] = useState<Layer[]>([])
 
   useEffect(() => {
     if (orders) {
       const withLocation = orders.filter((msg: MessagePlanning) => msg.message && (msg.message.location !== undefined))
-      const geometries = withLocation.map((msg: MessagePlanning): GeoJSON.Feature[] => {
+      const geometries = withLocation.map((msg: MessagePlanning): Feature[] => {
         if (msg.message.location) {
           const geoms = msg.message.location.map((act: PlannedActivityGeometry) => {
             const res = { ...act.geometry }
@@ -80,6 +41,8 @@ export const MapPlanningOrders: React.FC<PropTypes> = ({ orders, activities, for
               if (geometry) {
                 res.properties.name = geometry.name
               }
+            } else {
+              console.warn('failed to find activity for', act.uniqid, activities)
             }
             return res
           })
@@ -89,11 +52,26 @@ export const MapPlanningOrders: React.FC<PropTypes> = ({ orders, activities, for
         }
       })
       const flatGeom = _.flatten(geometries)
-      const geojson = {
-        type: 'FeatureCollection',
-        features: flatGeom
+
+      // handler to store layer references
+      const storeRef = (polyline: Layer): void => {
+        layersToDelete.push(polyline)
       }
-      setOrderGeometries(geojson as GeoJsonObject)
+
+      const elements = flatGeom.map((feature: Feature) => {
+        if (feature.properties) {
+          const activity = localFindActivity(activities, feature.properties.uniqid)
+          let color = forceColor || '#0f0'
+          if (activity && activity.color) {
+            color = activity.color
+          }
+          return shapeFor(feature, color, feature.properties ? feature.properties.name : 'unknown', storeRef)
+        } else {
+          return <></>
+        }
+      })
+
+      setOrderGeometries(elements)
     }
   }, [orders])
 
@@ -103,7 +81,7 @@ export const MapPlanningOrders: React.FC<PropTypes> = ({ orders, activities, for
       const timings = orders.map((msg: MessagePlanning) => {
         return '' + msg.message.title + ',' + msg.message.startDate + ', ' + msg.message.endDate
       })
-      console.log(timings)
+      console.log('timings', timings)
     }
   }, [orders])
 
@@ -111,7 +89,7 @@ export const MapPlanningOrders: React.FC<PropTypes> = ({ orders, activities, for
     {
       orderGeometries &&
       <LayerGroup key={'orders'}>
-        <GeoJSON style={styleFor} pointToLayer={pointToLayer} onEachFeature={onEachFeature} data={{ ...orderGeometries, type: 'FeatureCollection' }} />
+        { orderGeometries }
       </LayerGroup>
     }
   </>

--- a/packages/components/src/local/organisms/planning-channel/helpers/OrderPlotter.tsx
+++ b/packages/components/src/local/organisms/planning-channel/helpers/OrderPlotter.tsx
@@ -1,14 +1,13 @@
 import { MessagePlanning, PerForcePlanningActivitySet, PlannedProps } from '@serge/custom-types'
 import { deepCopy, ForceStyle } from '@serge/helpers'
-import { Position } from '@turf/turf'
-import { Feature, GeoJsonObject, LineString, Point, Polygon } from 'geojson'
-import { circleMarker, latLng, LatLng, Layer, PathOptions, StyleFunction } from 'leaflet'
+import { Feature, GeoJsonObject } from 'geojson'
+import { circleMarker, LatLng, Layer, PathOptions, StyleFunction } from 'leaflet'
 import _ from 'lodash'
 import moment from 'moment'
 import React, { useEffect, useState } from 'react'
-import { CircleMarker, GeoJSON, LayerGroup, Marker, Polygon as RPolygon, Tooltip } from 'react-leaflet-v4'
-import PolylineDecorator from '../../support-mapping/helper/PolylineDecorator'
-import { findPlannedGeometries, findPlanningGeometry, GeomWithOrders, injectTimes, invertMessages, overlapsInTime, PlanningContact, putInBin, SpatialBin, spatialBinning, touches } from '../../support-panel/helpers/gen-order-data'
+import { GeoJSON, LayerGroup, Marker, Tooltip } from 'react-leaflet-v4'
+import { findPlannedGeometries, GeomWithOrders, injectTimes, invertMessages, overlapsInTime, PlanningContact, putInBin, SpatialBin, spatialBinning, touches } from '../../support-panel/helpers/gen-order-data'
+import { shapeFor, shapeForGeomWithOrders } from './SharedOrderRenderer'
 
 export interface OrderPlotterProps {
   orders: MessagePlanning[]
@@ -305,44 +304,10 @@ export const OrderPlotter: React.FC<OrderPlotterProps> = ({ orders, step, activi
       properties: {}
     }
     return <>
-      {shapeForGeomWithOrders(contact.first, storeRef)}
-      {shapeForGeomWithOrders(contact.second, storeRef)}
+      {shapeForGeomWithOrders(contact.first, forceCols, activities, storeRef)}
+      {shapeForGeomWithOrders(contact.second, forceCols, activities, storeRef)}
       {interFeature && shapeFor(interFeature as Feature, hightlightColor, '', storeRef)}
     </>
-  }
-
-  const shapeForGeomWithOrders = (geom: GeomWithOrders, storeRef: { (polyline: Layer): void }): React.ReactElement => {
-    const geometry = geom.geometry
-    const force = geom.activity.details.from.forceId
-    const activity = findPlanningGeometry(geom.uniqid, force || '', activities)
-    const color = forceCols.find((value: ForceStyle) => value.forceId === force)
-    return shapeFor(geometry, (color && color.color) || '', activity, storeRef)
-  }
-
-  /** produce a shape for this feature */
-  const shapeFor = (feature: Feature, color: string, label: string, storeRef: { (polyline: Layer): void }): React.ReactElement => {
-    let res: React.ReactElement | undefined
-    switch (feature.geometry.type) {
-      case 'LineString': {
-        const ls = feature.geometry as LineString
-        const coords: LatLng[] = ls.coordinates.map((pos: Position) => latLng(pos[1], pos[0]))
-        res = <PolylineDecorator storeRef={storeRef} message={label} latlngs={coords} color={(color) || ''} />
-        break
-      }
-      case 'Polygon': {
-        const poly = feature.geometry as Polygon
-        const coords: LatLng[] = poly.coordinates[0].map((pos: Position) => latLng(pos[1], pos[0]))
-        res = <RPolygon color={(color) || ''} positions={coords} />
-        break
-      }
-      case 'Point': {
-        const poly = feature.geometry as Point
-        const centre: LatLng = latLng(poly.coordinates[1], poly.coordinates[0])
-        res = <CircleMarker color={(color) || ''} center={centre} />
-        break
-      }
-    }
-    return res || <></>
   }
 
   return <>

--- a/packages/components/src/local/organisms/planning-channel/helpers/SharedOrderRenderer.tsx
+++ b/packages/components/src/local/organisms/planning-channel/helpers/SharedOrderRenderer.tsx
@@ -1,0 +1,53 @@
+import { PerForcePlanningActivitySet } from '@serge/custom-types'
+import { ForceStyle } from '@serge/helpers'
+import { Position } from '@turf/turf'
+import { Feature, LineString, Point, Polygon } from 'geojson'
+import { latLng, LatLng, Layer } from 'leaflet'
+import React from 'react'
+import { CircleMarker, Polygon as RPolygon, Tooltip } from 'react-leaflet-v4'
+import PolylineDecorator from '../../support-mapping/helper/PolylineDecorator'
+import { findPlanningGeometry, GeomWithOrders } from '../../support-panel/helpers/gen-order-data'
+
+/** produce a shape for this feature */
+export const shapeFor = (feature: Feature, color: string, label: string, storeRef: { (polyline: Layer): void }): React.ReactElement => {
+  let res: React.ReactElement | undefined
+  switch (feature.geometry.type) {
+    case 'LineString': {
+      const ls = feature.geometry as LineString
+      const coords: LatLng[] = ls.coordinates.map((pos: Position) => latLng(pos[1], pos[0]))
+      res = <PolylineDecorator storeRef={storeRef} message={label} latlngs={coords} color={(color) || ''} />
+      break
+    }
+    case 'Polygon': {
+      const poly = feature.geometry as Polygon
+      const coords: LatLng[] = poly.coordinates[0].map((pos: Position) => latLng(pos[1], pos[0]))
+      res = <>
+        <RPolygon color={(color) || ''} positions={coords}>
+          {label &&
+            <Tooltip>{label}</Tooltip>
+          }
+        </RPolygon>
+      </>
+      break
+    }
+    case 'Point': {
+      const poly = feature.geometry as Point
+      const centre: LatLng = latLng(poly.coordinates[1], poly.coordinates[0])
+      res = <CircleMarker radius={30} color={(color) || ''} center={centre}>
+        {label &&
+          <Tooltip>{label}</Tooltip>
+        }
+      </CircleMarker>
+      break
+    }
+  }
+  return res || <></>
+}
+
+export const shapeForGeomWithOrders = (geom: GeomWithOrders, forceCols: ForceStyle[], activities: PerForcePlanningActivitySet[], storeRef: { (polyline: Layer): void }): React.ReactElement => {
+  const geometry = geom.geometry
+  const force = geom.activity.details.from.forceId
+  const activity = findPlanningGeometry(geom.uniqid, force || '', activities)
+  const color = forceCols.find((value: ForceStyle) => value.forceId === force)
+  return shapeFor(geometry, (color && color.color) || '', activity, storeRef)
+}

--- a/packages/components/src/local/organisms/planning-messages-list/index.tsx
+++ b/packages/components/src/local/organisms/planning-messages-list/index.tsx
@@ -12,7 +12,7 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({ messages, templates,
   const [columns, setColumns] = useState<Column[]>([])
   const [filter, setFilter] = useState<boolean>(false)
 
-  console.log('selectedOrders: ', selectedOrders, setSelectedOrders)
+  console.log('selectedOrders: ', selectedOrders, setSelectedOrders, messages.length)
 
   const [myMessages, setMyMessages] = useState<MessagePlanning[]>([])
   useEffect(() => {

--- a/packages/components/src/local/organisms/planning-messages-list/index.tsx
+++ b/packages/components/src/local/organisms/planning-messages-list/index.tsx
@@ -12,7 +12,7 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({ messages, templates,
   const [columns, setColumns] = useState<Column[]>([])
   const [filter, setFilter] = useState<boolean>(false)
 
-  console.log('selectedOrders: ', selectedOrders, setSelectedOrders, messages.length)
+  console.log('selectedOrders: ', selectedOrders, !!setSelectedOrders, messages.length)
 
   const [myMessages, setMyMessages] = useState<MessagePlanning[]>([])
   useEffect(() => {


### PR DESCRIPTION
The `Orders` objects weren't being rendered.

This PR fixes the issue, re-using code from the interaction generation code.