### PR TITLE
Hotfix prevent select asset during new activity drawing

### DIFF
--- a/packages/client/src/Views/ChannelTabsContainer/helpers/factory.tsx
+++ b/packages/client/src/Views/ChannelTabsContainer/helpers/factory.tsx
@@ -3,7 +3,7 @@ import {
   CHANNEL_CHAT, CHANNEL_COLLAB,
   CHANNEL_CUSTOM, CHANNEL_MAPPING, CHANNEL_PLANNING, CLONE_MARKER, CREATE_TASK_GROUP, DELETE_MARKER, DELETE_PLATFORM, FORCE_LAYDOWN, HOST_PLATFORM, LEAVE_TASK_GROUP, PERCEPTION_OF_CONTACT, Phase, STATE_OF_WORLD, SUBMIT_PLANS, UMPIRE_LAYDOWN, UPDATE_MARKER, VISIBILITY_CHANGES
 } from '@serge/config'
-import { ChannelMapping, ChannelPlanning, ChannelTypes, ChannelUI, MappingConstraints, MessageMap, PlayerUi } from '@serge/custom-types'
+import { ChannelMapping, ChannelPlanning, ChannelTypes, ChannelUI, MappingConstraints, MessageMap, PerForcePlanningActivitySet, PlayerUi } from '@serge/custom-types'
 import { sendMapMessage } from '@serge/helpers'
 import { TabNode, TabSetNode } from 'flexlayout-react'
 import _ from 'lodash'
@@ -15,6 +15,7 @@ import { useDispatch } from 'react-redux'
 import { saveNewActivityTimeMessage } from '../../../ActionsAndReducers/PlayerLog/PlayerLog_ActionCreators'
 import CollabChannel from '../../../Components/CollabChannel'
 import { usePlayerUiDispatch } from '../../../Store/PlayerUi'
+import { perForceMockActivityData } from './mock-activity-data'
 
 type Factory = (node: TabNode) => React.ReactNode
 
@@ -156,6 +157,8 @@ const factory = (state: PlayerUi): Factory => {
         case CHANNEL_CUSTOM:
           return <ChatChannel isCustomChannel={true} channelId={channel.uniqid} />
         case CHANNEL_PLANNING:
+          // TODO: get activity data from the database
+          const filledInPerForcePlanningActivities: PerForcePlanningActivitySet[] = perForceMockActivityData
           return <PlanningChannel
             templates={channel.templates}
             allTemplates={allTemplates}
@@ -179,6 +182,7 @@ const factory = (state: PlayerUi): Factory => {
             saveMessage={saveMessage}
             reduxDispatch={reduxDisplatch}
             saveNewActivityTimeMessage={saveNewActivityTimeMessage}
+            forcePlanningActivities={filledInPerForcePlanningActivities}
           />
         default:
           console.log('not yet handling', channelData)

--- a/packages/client/src/Views/ChannelTabsContainer/helpers/mock-activity-data.ts
+++ b/packages/client/src/Views/ChannelTabsContainer/helpers/mock-activity-data.ts
@@ -1,0 +1,697 @@
+export const perForceMockActivityData = [
+  {
+    force: 'F-Blue',
+    groupedActivities: [
+      {
+        category: 'Maritime',
+        activities: [
+          {
+            uniqid: 'precis-strike',
+            name: 'Precision Strike',
+            template: 'Air Activity',
+            color: '#f0f',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'aa1'
+              },
+              {
+                aType: 0,
+                name: 'Target Location',
+                uniqid: 'aa2'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'aa3'
+              }
+            ]
+          },
+          {
+            uniqid: 'area-strike',
+            name: 'Area Strike',
+            template: 'Air Activity',
+            color: '#b0f',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'aa4'
+              },
+              {
+                aType: 2,
+                name: 'Target Area',
+                uniqid: 'aa5'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'aa6'
+              }
+            ]
+          },
+          {
+            uniqid: 'transit',
+            name: 'Transit',
+            template: 'Maritime Activity',
+            color: '#f33',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route',
+                uniqid: 'aa7'
+              }
+            ]
+          },
+          {
+            uniqid: 'area-recce',
+            name: 'Area Reconnaisance',
+            template: 'Air Activity',
+            color: '#5b0',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'aa8'
+              },
+              {
+                aType: 2,
+                name: 'Target Area',
+                uniqid: 'aa9'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'a10'
+              }
+            ]
+          },
+          {
+            uniqid: 'point-recce',
+            name: 'Point Reconnaisance',
+            template: 'Air Activity',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'a11'
+              },
+              {
+                aType: 0,
+                name: 'Target Area',
+                uniqid: 'a12'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'a13'
+              }
+            ]
+          },
+          {
+            uniqid: 'cyber',
+            name: 'Non spatial cyber',
+            template: 'Other Activity'
+          }
+        ]
+      },
+      {
+        category: 'Land',
+        activities: [
+          {
+            uniqid: 'precis-strike',
+            name: 'Precision Strike',
+            template: 'Air Activity',
+            color: '#f0f',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'aa1'
+              },
+              {
+                aType: 0,
+                name: 'Target Location',
+                uniqid: 'aa2'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'aa3'
+              }
+            ]
+          },
+          {
+            uniqid: 'area-strike',
+            name: 'Area Strike',
+            template: 'Air Activity',
+            color: '#b0f',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'aa4'
+              },
+              {
+                aType: 2,
+                name: 'Target Area',
+                uniqid: 'aa5'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'aa6'
+              }
+            ]
+          },
+          {
+            uniqid: 'transit',
+            name: 'Transit',
+            template: 'Maritime Activity',
+            color: '#f33',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route',
+                uniqid: 'aa7'
+              }
+            ]
+          },
+          {
+            uniqid: 'area-recce',
+            name: 'Area Reconnaisance',
+            template: 'Air Activity',
+            color: '#5b0',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'aa8'
+              },
+              {
+                aType: 2,
+                name: 'Target Area',
+                uniqid: 'aa9'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'a10'
+              }
+            ]
+          },
+          {
+            uniqid: 'point-recce',
+            name: 'Point Reconnaisance',
+            template: 'Air Activity',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'a11'
+              },
+              {
+                aType: 0,
+                name: 'Target Area',
+                uniqid: 'a12'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'a13'
+              }
+            ]
+          },
+          {
+            uniqid: 'cyber',
+            name: 'Non spatial cyber',
+            template: 'Other Activity'
+          }
+        ]
+      },
+      {
+        category: 'Air',
+        activities: [
+          {
+            uniqid: 'precis-strike',
+            name: 'Precision Strike',
+            template: 'Air Activity',
+            color: '#f0f',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'aa1'
+              },
+              {
+                aType: 0,
+                name: 'Target Location',
+                uniqid: 'aa2'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'aa3'
+              }
+            ]
+          },
+          {
+            uniqid: 'area-strike',
+            name: 'Area Strike',
+            template: 'Air Activity',
+            color: '#b0f',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'aa4'
+              },
+              {
+                aType: 2,
+                name: 'Target Area',
+                uniqid: 'aa5'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'aa6'
+              }
+            ]
+          },
+          {
+            uniqid: 'transit',
+            name: 'Transit',
+            template: 'Maritime Activity',
+            color: '#f33',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route',
+                uniqid: 'aa7'
+              }
+            ]
+          },
+          {
+            uniqid: 'area-recce',
+            name: 'Area Reconnaisance',
+            template: 'Air Activity',
+            color: '#5b0',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'aa8'
+              },
+              {
+                aType: 2,
+                name: 'Target Area',
+                uniqid: 'aa9'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'a10'
+              }
+            ]
+          },
+          {
+            uniqid: 'point-recce',
+            name: 'Point Reconnaisance',
+            template: 'Air Activity',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'a11'
+              },
+              {
+                aType: 0,
+                name: 'Target Area',
+                uniqid: 'a12'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'a13'
+              }
+            ]
+          },
+          {
+            uniqid: 'cyber',
+            name: 'Non spatial cyber',
+            template: 'Other Activity'
+          }
+        ]
+      },
+      {
+        category: 'Other',
+        activities: [
+          {
+            uniqid: 'precis-strike',
+            name: 'Precision Strike',
+            template: 'Air Activity',
+            color: '#f0f',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'aa1'
+              },
+              {
+                aType: 0,
+                name: 'Target Location',
+                uniqid: 'aa2'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'aa3'
+              }
+            ]
+          },
+          {
+            uniqid: 'area-strike',
+            name: 'Area Strike',
+            template: 'Air Activity',
+            color: '#b0f',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'aa4'
+              },
+              {
+                aType: 2,
+                name: 'Target Area',
+                uniqid: 'aa5'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'aa6'
+              }
+            ]
+          },
+          {
+            uniqid: 'area-recce',
+            name: 'Area Reconnaisance',
+            template: 'Air Activity',
+            color: '#5b0',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'aa8'
+              },
+              {
+                aType: 2,
+                name: 'Target Area',
+                uniqid: 'aa9'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'a10'
+              }
+            ]
+          },
+          {
+            uniqid: 'point-recce',
+            name: 'Point Reconnaisance',
+            template: 'Air Activity',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'a11'
+              },
+              {
+                aType: 0,
+                name: 'Target Area',
+                uniqid: 'a12'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'a13'
+              }
+            ]
+          },
+          {
+            uniqid: 'cyber',
+            name: 'Non spatial cyber',
+            template: 'Other Activity'
+          }
+        ]
+      }
+    ]
+  },
+  {
+    force: 'F-Red',
+    groupedActivities: [
+      {
+        category: 'Maritime',
+        activities: [
+          {
+            uniqid: 'precis-strike',
+            name: 'Precision Strike',
+            template: 'Air Activity',
+            color: '#f0f',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'aa1'
+              },
+              {
+                aType: 0,
+                name: 'Target Location',
+                uniqid: 'aa2'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'aa3'
+              }
+            ]
+          },
+          {
+            uniqid: 'area-strike',
+            name: 'Area Strike',
+            template: 'Air Activity',
+            color: '#b0f',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'aa4'
+              },
+              {
+                aType: 2,
+                name: 'Target Area',
+                uniqid: 'aa5'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'aa6'
+              }
+            ]
+          },
+          {
+            uniqid: 'transit',
+            name: 'Transit',
+            template: 'Maritime Activity',
+            color: '#f33',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route',
+                uniqid: 'aa7'
+              }
+            ]
+          }
+        ]
+      },
+      {
+        category: 'Land',
+        activities: [
+          {
+            uniqid: 'precis-strike',
+            name: 'Precision Strike',
+            template: 'Air Activity',
+            color: '#f0f',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'aa1'
+              },
+              {
+                aType: 0,
+                name: 'Target Location',
+                uniqid: 'aa2'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'aa3'
+              }
+            ]
+          },
+          {
+            uniqid: 'point-recce',
+            name: 'Point Reconnaisance',
+            template: 'Air Activity',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'a11'
+              },
+              {
+                aType: 0,
+                name: 'Target Area',
+                uniqid: 'a12'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'a13'
+              }
+            ]
+          },
+          {
+            uniqid: 'cyber',
+            name: 'Non spatial cyber',
+            template: 'Other Activity'
+          }
+        ]
+      },
+      {
+        category: 'Air',
+        activities: [
+          {
+            uniqid: 'transit',
+            name: 'Transit',
+            template: 'Maritime Activity',
+            color: '#f33',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route',
+                uniqid: 'aa7'
+              }
+            ]
+          },
+          {
+            uniqid: 'area-recce',
+            name: 'Area Reconnaisance',
+            template: 'Air Activity',
+            color: '#5b0',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'aa8'
+              },
+              {
+                aType: 2,
+                name: 'Target Area',
+                uniqid: 'aa9'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'a10'
+              }
+            ]
+          },
+          {
+            uniqid: 'point-recce',
+            name: 'Point Reconnaisance',
+            template: 'Air Activity',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'a11'
+              },
+              {
+                aType: 0,
+                name: 'Target Area',
+                uniqid: 'a12'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'a13'
+              }
+            ]
+          },
+          {
+            uniqid: 'cyber',
+            name: 'Non spatial cyber',
+            template: 'Other Activity'
+          }
+        ]
+      },
+      {
+        category: 'Other',
+        activities: [
+          {
+            uniqid: 'precis-strike',
+            name: 'Precision Strike',
+            template: 'Air Activity',
+            color: '#f0f',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'aa1'
+              },
+              {
+                aType: 0,
+                name: 'Target Location',
+                uniqid: 'aa2'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'aa3'
+              }
+            ]
+          },
+          {
+            uniqid: 'point-recce',
+            name: 'Point Reconnaisance',
+            template: 'Air Activity',
+            geometries: [
+              {
+                aType: 1,
+                name: 'Route in',
+                uniqid: 'a11'
+              },
+              {
+                aType: 0,
+                name: 'Target Area',
+                uniqid: 'a12'
+              },
+              {
+                aType: 1,
+                name: 'Route out',
+                uniqid: 'a13'
+              }
+            ]
+          },
+          {
+            uniqid: 'cyber',
+            name: 'Non spatial cyber',
+            template: 'Other Activity'
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/components/src/local/organisms/planning-channel/index.tsx
+++ b/packages/components/src/local/organisms/planning-channel/index.tsx
@@ -69,6 +69,9 @@ export const PlanningChannel: React.FC<PropTypes> = ({
 
   // handle selections from asset tables
   const [selectedAssets, setSelectedAssets] = useState<string[]>([])
+  // have `local` selected assets handler, since we don't always want to
+  // propagate changes to selected assets
+  const [localSelectedAssets, setLocalSelectedAssets] = useState<string[]>([])
   const [selectedOrders, setSelectedOrders] = useState<string[]>([])
 
   const [mapWidth, setMapWidth] = useState<string>('calc(100% - 330px)')
@@ -110,6 +113,13 @@ export const PlanningChannel: React.FC<PropTypes> = ({
   useEffect(() => {
     console.log('selected orders updated')
   }, [selectedOrders])
+
+  useEffect(() => {
+    // only update selected assets if we're not planning an activity
+    if (!activityBeingPlanned) {
+      setSelectedAssets(localSelectedAssets)
+    }
+  }, [localSelectedAssets])
 
   useEffect(() => {
     // produce the own and opp assets for this player force
@@ -198,17 +208,6 @@ export const PlanningChannel: React.FC<PropTypes> = ({
     console.log('action clicked', force, category, actionId)
   }
 
-  // const onDrawingComplete = (geometries: PlannedActivityGeometry[]): void => {
-  //   setCurrentActivity(undefined)
-  //   window.alert('Geometries complete ' + geometries.length)
-  // }
-
-  // const startDrawing = (): void => {
-  //   if (planningActivities) {
-  //     setCurrentActivity(planningActivities[0])
-  //   }
-  // }
-
   const supportPanelContext = useMemo(() => ({ selectedAssets }), [selectedAssets])
 
   const genData = (): void => {
@@ -256,10 +255,10 @@ export const PlanningChannel: React.FC<PropTypes> = ({
           : <>
             <MapPlanningOrders forceColor={selectedForce.color} orders={planningMessages} activities={flattenedPlanningActivities} setSelectedOrders={noop} />
             <LayerGroup key={'own-forces'}>
-              <PlanningForces opFor={false} assets={filterApplied ? ownAssetsFiltered : allOwnAssets} setSelectedAssets={setSelectedAssets} selectedAssets={selectedAssets} />
+              <PlanningForces opFor={false} assets={filterApplied ? ownAssetsFiltered : allOwnAssets} setSelectedAssets={setLocalSelectedAssets} selectedAssets={selectedAssets} />
             </LayerGroup>
             <LayerGroup key={'opp-forces'}>
-              <PlanningForces opFor={true} assets={filterApplied ? opAssetsFiltered : allOppAssets} setSelectedAssets={setSelectedAssets} selectedAssets={selectedAssets} />
+              <PlanningForces opFor={true} assets={filterApplied ? opAssetsFiltered : allOppAssets} setSelectedAssets={setLocalSelectedAssets} selectedAssets={selectedAssets} />
             </LayerGroup>
             {/* <PolylineDecorator latlngs={polylineLatlgn} layer={geomanLayer} /> */}
           </>
@@ -293,7 +292,7 @@ export const PlanningChannel: React.FC<PropTypes> = ({
           gameDate={gameDate}
           currentTurn={currentTurn}
           selectedAssets={selectedAssets}
-          setSelectedAssets={setSelectedAssets}
+          setSelectedAssets={setLocalSelectedAssets}
           selectedOrders={selectedOrders}
           setSelectedOrders={setSelectedOrders}
           setOpForcesForParent={setOpAssetsFiltered}


### PR DESCRIPTION
Fix to provide planning activities to `develop` build, and to prevent assets being selected while an asset is being planned