### PR TITLE
Hotfix orders panel crash

### DIFF
--- a/packages/components/src/local/form-elements/new-message/index.tsx
+++ b/packages/components/src/local/form-elements/new-message/index.tsx
@@ -128,7 +128,7 @@ const NewMessage: React.FC<PropTypes> = ({
           selectedRoleName={selectedRoleName}
           postBack={postBack}
           customiseTemplate={customiseTemplate}
-          
+
         />
       </Collapsible>
     </div>

--- a/packages/components/src/local/molecules/json-editor/index.tsx
+++ b/packages/components/src/local/molecules/json-editor/index.tsx
@@ -204,10 +204,10 @@ export const JsonEditor: React.FC<Props> = ({
       {
         formId
           ? <>
-              <SaveMessageButton />
-              <div id={formId} ref={jsonEditorRef} />
-              <SaveMessageButton />
-            </>
+            <SaveMessageButton />
+            <div id={formId} ref={jsonEditorRef} />
+            <SaveMessageButton />
+          </>
           : <div className={formClassName || (disabled ? 'edt-disable' : 'edt-enable')} ref={jsonEditorRef} />
       }
     </>

--- a/packages/components/src/local/organisms/support-panel/index.tsx
+++ b/packages/components/src/local/organisms/support-panel/index.tsx
@@ -72,13 +72,15 @@ export const SupportPanel: React.FC<PropTypes> = ({
   }
 
   const customiseTemplate = (schema: Record<string, any>): Record<string, any> => {
-    const oldOwnAssets = schema.properties?.Assets?.items?.properties?.FEName?.enum
-    if (oldOwnAssets) {
-      schema.properties.Assets.items.properties.FEName.enum = allOwnAssets.map((asset: AssetRow) => asset.name)
-    }
-    const oldOwnTargets = schema.properties?.Targets?.items?.properties?.FEName?.enum
-    if (oldOwnTargets) {
-      schema.properties.Targets.items.properties.FEName.enum = allOppAssets.map((asset: AssetRow) => asset.name)
+    if (schema) {
+      const oldOwnAssets = schema.properties?.Assets?.items?.properties?.FEName?.enum
+      if (oldOwnAssets) {
+        schema.properties.Assets.items.properties.FEName.enum = allOwnAssets.map((asset: AssetRow) => asset.name)
+      }
+      const oldOwnTargets = schema.properties?.Targets?.items?.properties?.FEName?.enum
+      if (oldOwnTargets) {
+        schema.properties.Targets.items.properties.FEName.enum = allOppAssets.map((asset: AssetRow) => asset.name)
+      }  
     }
     return schema
   }

--- a/packages/components/src/local/organisms/support-panel/index.tsx
+++ b/packages/components/src/local/organisms/support-panel/index.tsx
@@ -80,7 +80,7 @@ export const SupportPanel: React.FC<PropTypes> = ({
       const oldOwnTargets = schema.properties?.Targets?.items?.properties?.FEName?.enum
       if (oldOwnTargets) {
         schema.properties.Targets.items.properties.FEName.enum = allOppAssets.map((asset: AssetRow) => asset.name)
-      }  
+      }
     }
     return schema
   }


### PR DESCRIPTION
`My orders` in planning channel was crashing the storybook.

This was because it was trying to render when the page hadn't fully loaded.

Fixed by checking input data