### PR TITLE
use the workaround from the `client` package for `leaflet.control.select`

### DIFF
--- a/packages/components/static/leaflet.select/leaflet.control.select.js
+++ b/packages/components/static/leaflet.select/leaflet.control.select.js
@@ -165,11 +165,8 @@ L.Control.Select = L.Control.extend({
   _setState(newState) {
     // events
     if (
-      this.options.onSelect &&
-      newState.selected &&
-      ((this.options.multi &&
-        newState.selected.length !== this.state.selected.length) ||
-        (!this.options.multi && newState.selected !== this.state.selected))
+      this.options.onSelect && newState.selected &&
+      ((this.options.multi && newState.selected.length !== this.state.selected.length) || !this.options.multi)
     ) {
       this.options.onSelect(newState.selected)
     }


### PR DESCRIPTION
The select control wasn't firing an event if the same menu option was selected more than once.

@lebaphi fixed the issue in our local codebase, in the `client` package

This PR reproduces the fix in the `components` package - so that it works in Storybook.