### PR TITLE
Can't read read-only text-boxes and drop-downs because text is white

### DIFF
--- a/packages/themes/_forms.scss
+++ b/packages/themes/_forms.scss
@@ -59,6 +59,11 @@
       @include game-admin-input;
     }
   }
+
+  &:disabled,
+  &[readonly] {
+    background-color: rgb(128, 128, 128) !important;
+  }
 }
 
 .react-select {


### PR DESCRIPTION
Fixes #2074 

<img width="768" alt="Screen Shot 2022-11-13 at 9 57 33 PM" src="https://user-images.githubusercontent.com/26705621/201528521-8f7bef40-e42d-45e0-a740-134ef71a6443.png">
