### PR TITLE
2091 Ensure geoman provides valid polygons

### DIFF
--- a/packages/components/src/local/organisms/planning-channel/helpers/OrderDrawing.tsx
+++ b/packages/components/src/local/organisms/planning-channel/helpers/OrderDrawing.tsx
@@ -76,7 +76,7 @@ export const OrderDrawing: React.FC<OrderDrawingProps> = ({ activity, planned, c
           })
           // if GeoMan hasn't closed the poly, do it for it
           const data = longLats[0]
-          if(!_.isEqual(data[0], data[data.length-1])) {
+          if (!_.isEqual(data[0], data[data.length - 1])) {
             data.push(data[0])
           }
           res = {

--- a/packages/components/src/local/organisms/planning-channel/helpers/OrderDrawing.tsx
+++ b/packages/components/src/local/organisms/planning-channel/helpers/OrderDrawing.tsx
@@ -74,6 +74,11 @@ export const OrderDrawing: React.FC<OrderDrawingProps> = ({ activity, planned, c
               return [pt2.lng, pt2.lat]
             })
           })
+          // if GeoMan hasn't closed the poly, do it for it
+          const data = longLats[0]
+          if(!_.isEqual(data[0], data[data.length-1])) {
+            data.push(data[0])
+          }
           res = {
             type: 'Polygon',
             coordinates: longLats
@@ -115,7 +120,8 @@ export const OrderDrawing: React.FC<OrderDrawingProps> = ({ activity, planned, c
         editable: false,
         allowCutting: false,
         allowRemoval: false,
-        allowRotation: false
+        allowRotation: false,
+        allowSelfIntersection: false
       }
 
       // switch off all controls

--- a/packages/components/src/local/organisms/planning-channel/helpers/OrderEditing.tsx
+++ b/packages/components/src/local/organisms/planning-channel/helpers/OrderEditing.tsx
@@ -4,6 +4,7 @@ import { PlannedActivityGeometry } from '@serge/custom-types'
 import { Feature } from 'geojson'
 import L, { LatLng, Layer, PM } from 'leaflet'
 import 'leaflet-notifications'
+import _ from 'lodash'
 import React, { useEffect, useState } from 'react'
 import { GeomanControls } from 'react-leaflet-geoman-v2'
 import { useMap } from 'react-leaflet-v4'
@@ -48,6 +49,10 @@ const layerToGeoJSON = (layer: GLayerObject): Feature | undefined => {
       coords = data.map((pt: LatLng[]): number[][] => {
         return pt.map((pt2: LatLng): number[] => switchLayer(pt2))
       })
+      const points = coords[0]
+      if (!_.isEqual(points[0], points[points.length - 1])) {
+        points.push(points[0])
+      }
       break
     }
     default:
@@ -115,7 +120,8 @@ export const OrderEditing: React.FC<OrderEditingProps> = ({ saved, activityBeing
         editable: true,
         allowCutting: false,
         allowRemoval: false,
-        allowRotation: false
+        allowRotation: false,
+        allowSelfIntersectionEdit: false
       }
       setGlobalOptions(globalOpts)
 

--- a/packages/components/src/local/organisms/planning-messages-list/index.tsx
+++ b/packages/components/src/local/organisms/planning-messages-list/index.tsx
@@ -57,7 +57,7 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
         roles.push(author)
       }
       const plan = message.message as PlanningMessageStructureCore
-  
+
       const row: OrderRow = {
         id: message._id,
         reference: message.message.Reference + ' (Turn ' + message.details.turnNumber + ')',
@@ -79,23 +79,23 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
     const trimmedActivities = activities.map((item) => trimActivity(playerForceId, item))
 
     const smallPadding: React.CSSProperties = {
-      paddingLeft: "10px",
-      paddingRight: "10px"
+      paddingLeft: '10px',
+      paddingRight: '10px'
     }
 
     const narrowCell: React.CSSProperties = {
-      ...smallPadding, width:"80px"
+      ...smallPadding, width: '80px'
     }
     const mediumCell: React.CSSProperties = {
-      ...smallPadding, width:"120px"
+      ...smallPadding, width: '120px'
     }
 
     const columnData: Column[] = jestWorkerId ? [] : [
-      { title: 'Reference', field: 'reference', cellStyle: mediumCell, headerStyle: mediumCell},
+      { title: 'Reference', field: 'reference', cellStyle: mediumCell, headerStyle: mediumCell },
       { title: 'Author', field: 'role', lookup: arrToDict(roles), cellStyle: narrowCell, headerStyle: narrowCell },
       { title: 'Title', field: 'title', cellStyle: smallPadding, headerStyle: smallPadding },
-      { title: 'Activity', field: 'activity', lookup: arrToDict(trimmedActivities) , cellStyle: smallPadding, headerStyle: smallPadding},
-      { title: 'Start Date', field: 'startDate', cellStyle: narrowCell , headerStyle: narrowCell},
+      { title: 'Activity', field: 'activity', lookup: arrToDict(trimmedActivities), cellStyle: smallPadding, headerStyle: smallPadding },
+      { title: 'Start Date', field: 'startDate', cellStyle: narrowCell, headerStyle: narrowCell },
       { title: 'Finish Date', field: 'endDate', cellStyle: narrowCell, headerStyle: narrowCell }
     ]
 


### PR DESCRIPTION
The polygons produced by the GeoMan drawing editor don't close themselves.  That is, the last element should be the same as the first.

Insert step to always close polygons generated by the tool.