### PR TITLE
fix to prevent sending `saved` twice

### DIFF
--- a/packages/components/src/local/organisms/planning-channel/helpers/OrderEditing.tsx
+++ b/packages/components/src/local/organisms/planning-channel/helpers/OrderEditing.tsx
@@ -100,7 +100,7 @@ export const OrderEditing: React.FC<OrderEditingProps> = ({ saved, activityBeing
       saved(res)
     }
     // clean up
-    cancelDrawing()
+    cleanUp()
   }
 
   useEffect(() => {
@@ -162,7 +162,7 @@ export const OrderEditing: React.FC<OrderEditingProps> = ({ saved, activityBeing
     }
   }, [activityBeingEdited])
 
-  const cancelDrawing = (): void => {
+  const cleanUp = (): void => {
     if (map) {
       if (editLayer) {
         editLayer.remove()
@@ -175,6 +175,10 @@ export const OrderEditing: React.FC<OrderEditingProps> = ({ saved, activityBeing
         layers.forEach((layer: Layer) => layer.remove())
       }
     }
+  }
+
+  const cancelDrawing = (): void => {
+    cleanUp()
     saved(undefined)
   }
 


### PR DESCRIPTION
The `OrderEditing` control was mistakenly firing twice on `save`. The second call had a value of `null`, which could effectively cancel the save.