### PR TITLE
Provide default start/end dates for new orders

### DIFF
--- a/packages/components/src/local/organisms/support-panel/index.tsx
+++ b/packages/components/src/local/organisms/support-panel/index.tsx
@@ -259,11 +259,12 @@ export const SupportPanel: React.FC<PropTypes> = ({
     })
 
     // set the default dates, if this is a planning message
-    const docAsAny = document as any
-    if (docAsAny.ownAssets !== undefined) {
-      const plan = document as PlanningMessageStructureCore
-      if (gameDate && (!plan.startDate || !plan.endDate)) {
+    const plan = document as PlanningMessageStructureCore
+    if (gameDate) {
+      if (!plan.startDate) {
         plan.startDate = gameDate
+      }
+      if (!plan.endDate) {
         plan.endDate = gameDate
       }
     }

--- a/packages/components/src/local/organisms/support-panel/index.tsx
+++ b/packages/components/src/local/organisms/support-panel/index.tsx
@@ -258,14 +258,18 @@ export const SupportPanel: React.FC<PropTypes> = ({
       }
     })
 
+    // check this isn't an adjudication message, since we only
     // set the default dates, if this is a planning message
     const plan = document as PlanningMessageStructureCore
-    if (gameDate) {
-      if (!plan.startDate) {
-        plan.startDate = gameDate
-      }
-      if (!plan.endDate) {
-        plan.endDate = gameDate
+    const schemaTitle: string = schema.title || 'unknown'
+    if (!schemaTitle.startsWith('Adjudicat')) {
+      if (gameDate) {
+        if (!plan.startDate) {
+          plan.startDate = gameDate
+        }
+        if (!plan.endDate) {
+          plan.endDate = gameDate
+        }
       }
     }
 


### PR DESCRIPTION
Minor fix, to specify game date even if there aren't ownAssets assigned.