### PR TITLE
2416: Persistent Planning Channel layout/status

### DIFF
--- a/packages/components/src/local/organisms/planning-assets/index.tsx
+++ b/packages/components/src/local/organisms/planning-assets/index.tsx
@@ -1,9 +1,12 @@
 import { faSearchMinus, faSearchPlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import MaterialTable, { Column, MTableBody, MTableBodyRow } from '@material-table/core'
+import { expiredStorage } from '@serge/config'
 import cx from 'classnames'
 import React, { useContext, useEffect, useRef, useState } from 'react'
+import { SUPPORT_PANEL_LAYOUT } from '../planning-channel'
 import { SupportPanelContext } from '../support-panel'
+import { TAB_MY_FORCE, TAB_OPP_FOR } from '../support-panel/constants'
 import { materialIcons } from '../support-panel/helpers/material-icons'
 import { getColumns } from './helpers/collate-assets'
 import CustomFilterRow from './helpers/custom-filter-row'
@@ -12,7 +15,7 @@ import PropTypes, { AssetRow } from './types/props'
 
 export const PlanningAssets: React.FC<PropTypes> = ({
   assets, forces, playerForce, opFor, platformStyles,
-  onSelectionChange, onVisibleRowsChange
+  onSelectionChange, onVisibleRowsChange, onVisibleColumnsChange
 }: PropTypes) => {
   const [rows, setRows] = useState<AssetRow[]>([])
   const [columns, setColumns] = useState<Column<any>[]>([])
@@ -43,7 +46,22 @@ export const PlanningAssets: React.FC<PropTypes> = ({
 
   useEffect(() => {
     if (!columns.length || !filter) {
-      setColumns(getColumns(opFor, forces, playerForce.uniqid, platformStyles, assetsCache))
+      const columns = getColumns(opFor, forces, playerForce.uniqid, platformStyles, assetsCache)
+      const cachedColumns = expiredStorage.getItem(SUPPORT_PANEL_LAYOUT.VISIBLE_COLUMNS)
+      if (cachedColumns) {
+        const parsedCols: { [x: string]: { field: string, hidden: string }[] } = JSON.parse(cachedColumns)
+        const key = opFor ? TAB_OPP_FOR : TAB_MY_FORCE;
+        (parsedCols[key] || []).map(mapCol => {
+          columns.some(col => {
+            if (col.field === mapCol.field) {
+              col.hidden = Boolean(mapCol.hidden)
+              return true
+            }
+            return false
+          })
+        })
+      }
+      setColumns(columns)
     }
   }, [playerForce, forces, filter])
 
@@ -100,9 +118,10 @@ export const PlanningAssets: React.FC<PropTypes> = ({
     onSelectionChange={onSelectionChangeLocal}
     components={{
       Body: (props): React.ReactElement => {
-        if (props.columns.length && onVisibleRowsChange) {
+        if (props.columns.length) {
           setTimeout(() => {
             setVisibleRows(props.renderData)
+            onVisibleColumnsChange && onVisibleColumnsChange(props.columns)
           })
         }
         return (<MTableBody

--- a/packages/components/src/local/organisms/planning-assets/types/props.d.ts
+++ b/packages/components/src/local/organisms/planning-assets/types/props.d.ts
@@ -1,5 +1,6 @@
 import { AttributeTypes, ForceData, PlatformTypeData } from '@serge/custom-types'
 import { ForceStyle, PlatformStyle } from '@serge/helpers'
+import { Column } from '@material-table/core'
 import { LatLng } from 'leaflet'
 
 export type AssetRow = {
@@ -41,6 +42,8 @@ export default interface PropTypes {
   onSelectionChange?: (rows: AssetRow[]) => void
   /** visible rows change callback */
   onVisibleRowsChange?: (row: AssetRow[]) => void
+
+  onVisibleColumnsChange?: (columns: Column<any>[]) => void
   /**
    *  set of assets visible to me
    */

--- a/packages/components/src/local/organisms/planning-channel/index.tsx
+++ b/packages/components/src/local/organisms/planning-channel/index.tsx
@@ -1,4 +1,4 @@
-import { INFO_MESSAGE_CLIPPED, INTERACTION_MESSAGE, PLANNING_MESSAGE, PLANNING_PHASE, UNKNOWN_TYPE } from '@serge/config'
+import { expiredStorage, INFO_MESSAGE_CLIPPED, INTERACTION_MESSAGE, PLANNING_MESSAGE, PLANNING_PHASE, UNKNOWN_TYPE } from '@serge/config'
 import { AreaCategory, Asset, ForceData, GroupedActivitySet, MessageInfoTypeClipped, MessagePlanning, PerForcePlanningActivitySet, PlainInteraction, PlannedActivityGeometry, PlannedProps, PlanningActivity } from '@serge/custom-types'
 import { clearUnsentMessage, findAsset, forceColors as getForceColors, ForceStyle, getUnsentMessage, platformIcons, saveUnsentMessage } from '@serge/helpers'
 import cx from 'classnames'
@@ -46,6 +46,14 @@ type PerForceAssets = {
   force: ForceData['uniqid']
   color: string
   rows: AssetRow[]
+}
+
+export const SUPPORT_PANEL_LAYOUT = {
+  OPENING_TAB: 'opening_tab',
+  SUPPORT_PANEL_WIDTH: 'support_panel_width',
+  VISIBLE_COLUMNS: 'visible_columns',
+  FILTERING: 'filtering',
+  SORT_COLUMNS: 'sort_columns'
 }
 
 export const PlanningChannel: React.FC<PropTypes> = ({
@@ -481,8 +489,12 @@ export const PlanningChannel: React.FC<PropTypes> = ({
     console.log('action clicked', force, category, actionId)
   }
 
+  const onSupportPanelLayoutChange = (key: string, value: string) => {
+    expiredStorage.setItem(key, value)
+  }
+
   const supportPanelContext = useMemo(() => (
-    { selectedAssets, setCurrentAssets: setCurrentAssetIds, setCurrentOrders, setCurrentInteraction: setCurrentInteraction, assetsCache }
+    { selectedAssets, setCurrentAssets: setCurrentAssetIds, setCurrentOrders, setCurrentInteraction: setCurrentInteraction, assetsCache, onSupportPanelLayoutChange }
   ), [selectedAssets, setCurrentAssetIds, setCurrentOrders, setCurrentInteraction, assetsCache])
 
   const incrementDebugStep = (): void => {

--- a/packages/components/src/local/organisms/support-panel/index.tsx
+++ b/packages/components/src/local/organisms/support-panel/index.tsx
@@ -1,10 +1,11 @@
 import Slide from '@material-ui/core/Slide'
 import MoreVert from '@material-ui/icons/MoreVert'
-import { ADJUDICATION_PHASE, MESSAGE_SENT_INTERACTION } from '@serge/config'
+import { ADJUDICATION_PHASE, expiredStorage, MESSAGE_SENT_INTERACTION } from '@serge/config'
 import { MessageDetails, MessageInteraction, MessagePlanning, MessageSentInteraction, MessageStructure, PerForcePlanningActivitySet, PlannedActivityGeometry, PlannedProps, PlanningMessageStructureCore } from '@serge/custom-types'
 import { forceColors, ForceStyle, incrementGameTime, platformIcons, PlatformStyle } from '@serge/helpers'
 import { updateLocationNames } from '@serge/helpers/build/geometry-helpers'
 import cx from 'classnames'
+import { Column } from '@material-table/core'
 import { noop } from 'lodash'
 import LRU from 'lru-cache'
 import moment from 'moment'
@@ -15,6 +16,7 @@ import AdjudicationMessagesList from '../adjudication-messages-list'
 import { AdjudicationRow } from '../adjudication-messages-list/types/props'
 import PlanningAssets from '../planning-assets'
 import { AssetRow } from '../planning-assets/types/props'
+import { SUPPORT_PANEL_LAYOUT } from '../planning-channel'
 import PlanningMessagesList from '../planning-messages-list'
 import { collapseLocation, expandLocation } from '../planning-messages-list/helpers/collapse-location'
 import { OrderRow } from '../planning-messages-list/types/props'
@@ -28,7 +30,7 @@ import { updateLocationTimings } from './helpers/update-location-timings'
 import styles from './styles.module.scss'
 import PropTypes, { PanelActionTabsProps, SupportPanelContextInterface } from './types/props'
 
-export const SupportPanelContext = createContext<SupportPanelContextInterface>({ selectedAssets: [], setCurrentAssets: noop, setCurrentOrders: noop, setCurrentInteraction: noop, assetsCache: new LRU<string, string>(LRU_CACHE_OPTION) })
+export const SupportPanelContext = createContext<SupportPanelContextInterface>({ selectedAssets: [], setCurrentAssets: noop, setCurrentOrders: noop, setCurrentInteraction: noop, assetsCache: new LRU<string, string>(LRU_CACHE_OPTION), onSupportPanelLayoutChange: noop })
 
 export const SupportPanel: React.FC<PropTypes> = ({
   platformTypes,
@@ -88,15 +90,42 @@ export const SupportPanel: React.FC<PropTypes> = ({
   const [localDraftMessage, setLocalDraftMessage] = useState<MessagePlanning | undefined>(undefined)
   const [activitiesForThisForce, setActivitiesForThisForce] = useState<PerForcePlanningActivitySet | undefined>(undefined)
   const [pendingLocationData, setPendingLocationData] = useState<PlannedActivityGeometry[]>([])
-  const { setCurrentOrders, setCurrentAssets, setCurrentInteraction } = useContext(SupportPanelContext)
+  const { setCurrentOrders, setCurrentAssets, setCurrentInteraction, onSupportPanelLayoutChange } = useContext(SupportPanelContext)
 
   const onTabChange = (tab: string): void => {
     setShowPanel(activeTab !== tab || !isShowPanel)
     setActiveTab(tab)
+    onSupportPanelLayoutChange(SUPPORT_PANEL_LAYOUT.OPENING_TAB, tab)
+  }
+
+  const getPanelWidthFromCache = () => {
+    const panelWidth = expiredStorage.getItem(SUPPORT_PANEL_LAYOUT.SUPPORT_PANEL_WIDTH)
+    if (panelWidth && !isNaN(parseInt(panelWidth))) {
+      return parseInt(panelWidth)
+    }
+    return MIN_PANEL_WIDTH
   }
 
   useEffect(() => {
+    const openingTab = expiredStorage.getItem(SUPPORT_PANEL_LAYOUT.OPENING_TAB)
+    if (openingTab) {
+      setActiveTab(openingTab)
+    }
+    setTimeout(() => {
+      const panelWidth = getPanelWidthFromCache()
+      if (panelWidth !== MIN_PANEL_WIDTH) {
+        onPanelWidthChange && onPanelWidthChange(panelWidth)
+      } else {
+        onSupportPanelLayoutChange(SUPPORT_PANEL_LAYOUT.SUPPORT_PANEL_WIDTH, '' + panelWidth)
+      }
+    })
+  }, [])
+
+  useEffect(() => {
     setLocalDraftMessage(draftMessage)
+    if (draftMessage) {
+      setActiveTab(TAB_MY_ORDERS)
+    }
   }, [draftMessage])
 
   useEffect(() => {
@@ -188,14 +217,7 @@ export const SupportPanel: React.FC<PropTypes> = ({
   }, [selectedOwnAssets, selectedOpAssets])
 
   useEffect(() => {
-    // if there is a draft message, open the `my orders` tab
-    if (draftMessage) {
-      setActiveTab(TAB_MY_ORDERS)
-    }
-  }, [draftMessage])
-
-  useEffect(() => {
-    onPanelWidthChange && onPanelWidthChange(isShowPanel ? 330 : 0)
+    onPanelWidthChange && onPanelWidthChange(isShowPanel ? MIN_PANEL_WIDTH : 0)
   }, [isShowPanel])
 
   const onVisibleRowsChange = (opFor: boolean, data: AssetRow[]): void => {
@@ -234,6 +256,7 @@ export const SupportPanel: React.FC<PropTypes> = ({
   }
 
   const onSizeChange = (_: MouseEvent | TouchEvent, __: any, elementRef: HTMLElement): void => {
+    onSupportPanelLayoutChange(SUPPORT_PANEL_LAYOUT.SUPPORT_PANEL_WIDTH, '' + elementRef.offsetWidth)
     onPanelWidthChange && onPanelWidthChange(elementRef.offsetWidth)
   }
 
@@ -403,6 +426,25 @@ export const SupportPanel: React.FC<PropTypes> = ({
     return planDoc
   }
 
+  const mapColumnState = (activeTab: string, columns: Column<any>[]): string => {
+    const mapCols = columns.map(col => ({ field: col.field, hidden: col.hidden || false }))
+    const objRes = {}
+    objRes[activeTab] = mapCols
+    return JSON.stringify(objRes)
+  }
+
+  const onMyForceTableColumnChange = (columns: Column<any>[]) => {
+    if (activeTab === TAB_MY_FORCE) {
+      onSupportPanelLayoutChange(SUPPORT_PANEL_LAYOUT.VISIBLE_COLUMNS, mapColumnState(activeTab, columns))
+    }
+  }
+
+  const onOtherForceTableColumnChange = (columns: Column<any>[]) => {
+    if (activeTab === TAB_OPP_FOR) {
+      onSupportPanelLayoutChange(SUPPORT_PANEL_LAYOUT.VISIBLE_COLUMNS, mapColumnState(activeTab, columns))
+    }
+  }
+
   return (
     <div className={styles.root}>
       <Slide direction="right" in={isShowPanel}>
@@ -410,7 +452,7 @@ export const SupportPanel: React.FC<PropTypes> = ({
           <Rnd
             disableDragging
             style={PANEL_STYLES}
-            default={DEFAULT_SIZE}
+            default={{ ...DEFAULT_SIZE, width: getPanelWidthFromCache() }}
             minWidth={MIN_PANEL_WIDTH}
             maxWidth={MAX_PANEL_WIDTH}
             minHeight={MIN_PANEL_HEIGHT}
@@ -431,6 +473,7 @@ export const SupportPanel: React.FC<PropTypes> = ({
                   opFor={false}
                   onSelectionChange={setSelectedOwnAssets}
                   onVisibleRowsChange={(data): void => onVisibleRowsChange(false, data)}
+                  onVisibleColumnsChange={onMyForceTableColumnChange}
                 />
               </div>
               <div className={cx({ [styles['tab-panel']]: true, [styles.hide]: activeTab !== TAB_MY_ORDERS })}>
@@ -502,6 +545,7 @@ export const SupportPanel: React.FC<PropTypes> = ({
                   opFor={true}
                   onSelectionChange={setSelectedOpAssets}
                   onVisibleRowsChange={(data): void => onVisibleRowsChange(true, data)}
+                  onVisibleColumnsChange={onOtherForceTableColumnChange}
                 />
               </div>
               <div className={cx({ [styles['tab-panel']]: true, [styles.hide]: activeTab !== TAB_ADJUDICATE })}>

--- a/packages/components/src/local/organisms/support-panel/types/props.d.ts
+++ b/packages/components/src/local/organisms/support-panel/types/props.d.ts
@@ -95,4 +95,5 @@ export type SupportPanelContextInterface = {
   setCurrentAssets: React.Dispatch<React.SetStateAction<string[]>>
   setCurrentOrders: React.Dispatch<React.SetStateAction<string[]>>
   setCurrentInteraction: React.Dispatch<React.SetStateAction<string | undefined>>
+  onSupportPanelLayoutChange: (key: string, value: string) => void
 }


### PR DESCRIPTION
Fixes #2416 

* [x] Current tab
* [x] Current width of support panel
* For tables:
    * [x] Currently visible columns
    * [ ] Whether filters are shown
    * [ ] Which filters are applied
    * [ ] Sort on any columns