### PR TITLE
Update toolbar controls on state change

### DIFF
--- a/packages/components/src/local/organisms/planning-messages-list/index.tsx
+++ b/packages/components/src/local/organisms/planning-messages-list/index.tsx
@@ -88,14 +88,14 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
       // also provide the `achive` button
       res.unshift({
         icon: () => <FontAwesomeIcon title='Archive selected messages' icon={faTrashAlt} className={cx({ [styles.selected]: filter })} />,
-        iconProps: filter ? { color: 'error' } : { color: 'action' },
+        iconProps: { color: 'action' },
         tooltip: 'Archive messages',
         isFreeAction: false,
         onClick: (_event: any, data: OrderRow | OrderRow[]): void => archiveSelected(data)
       })
     }
     setToolbarActions(res)
-  }, [isUmpire])
+  }, [isUmpire, filter, onlyShowMyOrders])
 
   // useEffect hook serves asynchronously, whereas the useLayoutEffect hook works synchronously
   useLayoutEffect(() => {


### PR DESCRIPTION
The planning messages page wasn't updating when we clicked on "show filters" or "only show my messages".

We needed to update the `toolbar state` when either of these items of state changed.