### PR TITLE
Hotfix allow current assets to be undefined

### DIFF
--- a/packages/components/src/local/organisms/planning-force/index.tsx
+++ b/packages/components/src/local/organisms/planning-force/index.tsx
@@ -91,7 +91,7 @@ const PlanningForces: React.FC<PropTypes> = ({
       assets.forEach((asset) => {
         // check we have position
         if (asset.position) {
-          if (!clusterIcons || selectedAssets.includes(asset.id) || currentAssets.includes(asset.id)) {
+          if (!clusterIcons || selectedAssets.includes(asset.id) || (currentAssets && currentAssets.includes(asset.id))) {
             raw.push(asset)
           } else {
             clustered.push(asset)
@@ -209,7 +209,7 @@ const PlanningForces: React.FC<PropTypes> = ({
   const getRawMarkerOption = (asset: AssetRow) => {
     const loc: LatLng = asset.position ? asset.position : latLng([0, 0])
     const isSelected = selectedAssets.includes(asset.id)
-    const isCurrent = currentAssets.includes(asset.id)
+    const isCurrent = currentAssets && currentAssets.includes(asset.id)
     const isDestroyed = asset.health && asset.health === 0
     return {
       eventHandlers: {
@@ -233,7 +233,7 @@ const PlanningForces: React.FC<PropTypes> = ({
     const loc: LatLng = asset.position ? asset.position : latLng([0, 0])
     const isSelected = selectedAssets.includes(asset.id)
     const isDestroyed = asset.health && asset.health === 0
-    const isCurrent = currentAssets.includes(asset.id)
+    const isCurrent = currentAssets && currentAssets.includes(asset.id)
 
     const interactiveIcon = (): void => {
       if (interactive) {

--- a/packages/components/src/local/organisms/planning-force/types/props.d.ts
+++ b/packages/components/src/local/organisms/planning-force/types/props.d.ts
@@ -11,7 +11,7 @@ export default interface PropTypes {
   /** id of selected asset (not clustered, highlighted with pulsing) */
   selectedAssets: string[]
   /** current assets (not clustered) */
-  currentAssets: string[]
+  currentAssets: string[] | undefined
   setSelectedAssets: (assets: string[]) => void
   interactive?: boolean
   /** name of this force */

--- a/packages/components/src/local/organisms/support-panel/index.tsx
+++ b/packages/components/src/local/organisms/support-panel/index.tsx
@@ -9,7 +9,7 @@ import { Column } from '@material-table/core'
 import { noop } from 'lodash'
 import LRU from 'lru-cache'
 import moment from 'moment'
-import React, { createContext, useContext, useEffect, useState, useRef } from 'react'
+import React, { createContext, useContext, useEffect, useState, useRef, useMemo, useCallback } from 'react'
 import { Rnd } from 'react-rnd'
 import NewMessage from '../../form-elements/new-message'
 import AdjudicationMessagesList from '../adjudication-messages-list'
@@ -92,6 +92,9 @@ export const SupportPanel: React.FC<PropTypes> = ({
   const [activitiesForThisForce, setActivitiesForThisForce] = useState<PerForcePlanningActivitySet | undefined>(undefined)
   const [pendingLocationData, setPendingLocationData] = useState<PlannedActivityGeometry[]>([])
   const { setCurrentOrders, setCurrentAssets, setCurrentInteraction, onSupportPanelLayoutChange } = useContext(SupportPanelContext)
+
+  const [pendingDetailOpen, setPendingDetailOpen] = useState<undefined | OrderRow | AdjudicationRow>(undefined)
+  const [pendingDetailClose, setPendingDetailClose] = useState<boolean>(false)
 
   const onTabChange = (tab: string): void => {
     setShowPanel(activeTab !== tab || !isShowPanel)
@@ -332,49 +335,64 @@ export const SupportPanel: React.FC<PropTypes> = ({
     return res
   }
 
-  const onDetailPanelOpen = (rowData: OrderRow | AdjudicationRow) => {
-    // if this is an orders item, or an adjudication, mark the relevant data
-    // as 'current
-    switch (activeTab) {
-      case TAB_MY_ORDERS: {
-        const order = rowData as OrderRow
-        const plan = planningMessages.find((msg) => msg._id === order.id)
-        if (plan) {
-          const mine = plan.message.ownAssets || []
-          const myIds = mine.map((val: { asset: string, number: number }): string => val.asset)
-          const others = plan.message.otherAssets ? plan.message.otherAssets.map((val: { asset: string }): string => val.asset) : []
-          const allIds = myIds.concat(others)
-          setCurrentAssets(allIds)
-          setCurrentOrders([plan._id])
+  useEffect(() => {
+    if (pendingDetailOpen) {
+      const rowData = pendingDetailOpen
+      setPendingDetailOpen(undefined)
+      switch (activeTab) {
+        case TAB_MY_ORDERS: {
+          const order = rowData as OrderRow
+          const plan = planningMessages.find((msg) => msg._id === order.id)
+          if (plan) {
+            const mine = plan.message.ownAssets || []
+            const myIds = mine.map((val: { asset: string, number: number }): string => val.asset)
+            const others = plan.message.otherAssets ? plan.message.otherAssets.map((val: { asset: string }): string => val.asset) : []
+            const allIds = myIds.concat(others)
+            setCurrentAssets(allIds)
+            setCurrentOrders([plan._id])
+          }
+          break
         }
-        break
-      }
-      case TAB_ADJUDICATE: {
-        const adj = rowData as AdjudicationRow
-
-        const doc = interactionMessages.find((doc) => doc._id === adj.id)
-        if (doc) {
-          const inter = doc.details.interaction
-          if (inter) {
-            // get the assets
-            const assets1 = assetsForOrders(inter.orders1)
-            const assets2 = assetsForOrders(inter.orders2)
-            const assets3 = inter.otherAssets || []
-            const allAssets = assets1.concat(assets2).concat(assets3)
-            setCurrentAssets(allAssets)
-            setCurrentInteraction(adj.reference)
+        case TAB_ADJUDICATE: {
+          const adj = rowData as AdjudicationRow
+  
+          const doc = interactionMessages.find((doc) => doc._id === adj.id)
+          if (doc) {
+            const inter = doc.details.interaction
+            if (inter) {
+              // get the assets
+              const assets1 = assetsForOrders(inter.orders1)
+              const assets2 = assetsForOrders(inter.orders2)
+              const assets3 = inter.otherAssets || []
+              const allAssets = assets1.concat(assets2).concat(assets3)
+              setCurrentAssets(allAssets)
+              setCurrentInteraction(adj.reference)
+            }
           }
         }
       }
     }
+  }, [planningMessages, interactionMessages, pendingDetailOpen, activeTab])
+
+  useEffect(() => {
+    if (pendingDetailClose) {
+      setPendingDetailClose(false)
+      setPendingDetailClose(true)
+      setCurrentAssets(undefined)
+      setCurrentOrders([])
+      if (activeTab === TAB_ADJUDICATE) {
+        setCurrentInteraction(undefined)
+      }  
+    }
+  }, [pendingDetailClose, activeTab])
+
+
+  const onDetailPanelOpen = (rowData: OrderRow | AdjudicationRow) => {
+    // we need the page state to handle this, so push into state
+    setPendingDetailOpen(rowData)
   }
 
   const onDetailPanelClose = () => {
-    setCurrentAssets(undefined)
-    setCurrentOrders([])
-    if (activeTab === TAB_ADJUDICATE) {
-      setCurrentInteraction(undefined)
-    }
   }
 
   const storeNewLocation = (geoms: PlannedActivityGeometry[]): void => {

--- a/packages/components/src/local/organisms/support-panel/index.tsx
+++ b/packages/components/src/local/organisms/support-panel/index.tsx
@@ -370,7 +370,7 @@ export const SupportPanel: React.FC<PropTypes> = ({
   }
 
   const onDetailPanelClose = () => {
-    setCurrentAssets([])
+    setCurrentAssets(undefined)
     setCurrentOrders([])
     if (activeTab === TAB_ADJUDICATE) {
       setCurrentInteraction(undefined)

--- a/packages/components/src/local/organisms/support-panel/index.tsx
+++ b/packages/components/src/local/organisms/support-panel/index.tsx
@@ -9,7 +9,7 @@ import { Column } from '@material-table/core'
 import { noop } from 'lodash'
 import LRU from 'lru-cache'
 import moment from 'moment'
-import React, { createContext, useContext, useEffect, useState, useRef, useMemo, useCallback } from 'react'
+import React, { createContext, useContext, useEffect, useState, useRef } from 'react'
 import { Rnd } from 'react-rnd'
 import NewMessage from '../../form-elements/new-message'
 import AdjudicationMessagesList from '../adjudication-messages-list'
@@ -355,7 +355,7 @@ export const SupportPanel: React.FC<PropTypes> = ({
         }
         case TAB_ADJUDICATE: {
           const adj = rowData as AdjudicationRow
-  
+
           const doc = interactionMessages.find((doc) => doc._id === adj.id)
           if (doc) {
             const inter = doc.details.interaction
@@ -377,15 +377,13 @@ export const SupportPanel: React.FC<PropTypes> = ({
   useEffect(() => {
     if (pendingDetailClose) {
       setPendingDetailClose(false)
-      setPendingDetailClose(true)
       setCurrentAssets(undefined)
       setCurrentOrders([])
       if (activeTab === TAB_ADJUDICATE) {
         setCurrentInteraction(undefined)
-      }  
+      }
     }
   }, [pendingDetailClose, activeTab])
-
 
   const onDetailPanelOpen = (rowData: OrderRow | AdjudicationRow) => {
     // we need the page state to handle this, so push into state
@@ -393,6 +391,7 @@ export const SupportPanel: React.FC<PropTypes> = ({
   }
 
   const onDetailPanelClose = () => {
+    setPendingDetailClose(true)
   }
 
   const storeNewLocation = (geoms: PlannedActivityGeometry[]): void => {

--- a/packages/components/src/local/organisms/support-panel/types/props.d.ts
+++ b/packages/components/src/local/organisms/support-panel/types/props.d.ts
@@ -92,7 +92,7 @@ export type PanelActionTabsProps = {
 export type SupportPanelContextInterface = {
   selectedAssets: string[]
   assetsCache: LRUCache<string, string>
-  setCurrentAssets: React.Dispatch<React.SetStateAction<string[]>>
+  setCurrentAssets: React.Dispatch<React.SetStateAction<string[] | undefined>>
   setCurrentOrders: React.Dispatch<React.SetStateAction<string[]>>
   setCurrentInteraction: React.Dispatch<React.SetStateAction<string | undefined>>
   onSupportPanelLayoutChange: (key: string, value: string) => void


### PR DESCRIPTION
Two issues:
1. When we expanded an orders with zero assets, all assets remained on screen.  This was because we were only filtering to current selection if it was a non-zero length list.  Instead, we use `undefined` to mean `no filter applied`, and a zero-length list to mean `this set of orders requires the display of zero assets
2. When we were expanding an orders item, the map only focussed on those orders if Serge opened on the Orders tab.  The handler just had the initial state of `activeTab`. So instead, we moved the processing into `state`. 