### PR TITLE
2141 - losing orders being edited

### DIFF
--- a/packages/components/src/local/molecules/json-editor/index.tsx
+++ b/packages/components/src/local/molecules/json-editor/index.tsx
@@ -29,6 +29,7 @@ export const JsonEditor: React.FC<Props> = ({
   disableArrayToolsWithEditor = true,
   clearForm,
   saveMessage,
+  onCancelEdit,
   modifyForSave,
   confirmCancel = false,
   viewSaveButton = false,
@@ -102,6 +103,7 @@ export const JsonEditor: React.FC<Props> = ({
     if (!viewSaveButton) {
       initEditor()
     }
+    onCancelEdit && onCancelEdit()
     setConfirmIsOpen(false)
     setBeingEdited(false)
   }

--- a/packages/components/src/local/molecules/json-editor/index.tsx
+++ b/packages/components/src/local/molecules/json-editor/index.tsx
@@ -1,6 +1,7 @@
 import { Editor, PlannedActivityGeometry, TemplateBody } from '@serge/custom-types'
 import { deepCopy, usePrevious } from '@serge/helpers'
 import 'bootstrap/dist/css/bootstrap.min.css'
+import { isEqual } from 'lodash'
 import moment from 'moment'
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Button } from '../../atoms/button'
@@ -38,6 +39,7 @@ export const JsonEditor: React.FC<Props> = ({
   const [editor, setEditor] = useState<Editor | null>(null)
   const [beingEdited, setBeingEdited] = useState<boolean>(false)
   const [confirmIsOpen, setConfirmIsOpen] = useState<boolean>(false)
+  const [originalMessage] = useState<string>(JSON.stringify(messageContent))
 
   const prevTemplates: TemplateBody = usePrevious(messageId)
   if (!template) {
@@ -83,7 +85,9 @@ export const JsonEditor: React.FC<Props> = ({
      */
     const fixedDate = fixDate(value)
     const newDoc = modifyForSave ? modifyForSave(fixedDate) : fixedDate
-    storeNewValue && storeNewValue(newDoc)
+    if (!isEqual(JSON.stringify(newDoc), originalMessage)) {
+      storeNewValue && storeNewValue(newDoc)
+    }
   }
 
   const OnSave = () => {

--- a/packages/components/src/local/molecules/json-editor/index.tsx
+++ b/packages/components/src/local/molecules/json-editor/index.tsx
@@ -1,5 +1,5 @@
 import { Editor, PlannedActivityGeometry, TemplateBody } from '@serge/custom-types'
-import { deepCopy, usePrevious } from '@serge/helpers'
+import { configDateTimeLocal, deepCopy, usePrevious } from '@serge/helpers'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import { isEqual } from 'lodash'
 import moment from 'moment'
@@ -55,8 +55,6 @@ export const JsonEditor: React.FC<Props> = ({
   const destroyEditor = (editorObject: Editor | null): void => {
     if (editorObject && (editorObject.ready || !editorObject.destroyed)) { editorObject.destroy() }
   }
-
-  console.log('Note: JSON Editor not pre-configuring game date. Do it via customiseTemplate helper', gameDate)
 
   const fixDate = (value: { [property: string]: any }): { [property: string]: any } => {
     const cleanDate = (date: string): string => {
@@ -132,7 +130,8 @@ export const JsonEditor: React.FC<Props> = ({
       : { disableArrayReOrder: false, disableArrayAdd: false, disableArrayDelete: false }
 
     // initialise date editors
-    const modSchema = template.details // configDateTimeLocal(template.details, gameDate)
+    gameDate && console.warn('Note: JSON Editor not pre-configuring game date. Do it via customiseTemplate helper', gameDate)
+    const modSchema = gameDate ? configDateTimeLocal(template.details, gameDate) : template.details
 
     // apply any other template modifications
     const customizedSchema = customiseTemplate ? customiseTemplate(messageContent, modSchema) : modSchema

--- a/packages/components/src/local/molecules/json-editor/types/props.d.ts
+++ b/packages/components/src/local/molecules/json-editor/types/props.d.ts
@@ -24,6 +24,7 @@ export default interface Props {
    */
   title?: string
   saveMessage?: () => void
+  onCancelEdit?: () => void
   confirmCancel?: boolean
   /**
    * whether the form is editable (disable for read-only view)

--- a/packages/components/src/local/molecules/json-editor/types/props.d.ts
+++ b/packages/components/src/local/molecules/json-editor/types/props.d.ts
@@ -24,6 +24,8 @@ export default interface Props {
    */
   title?: string
   saveMessage?: () => void
+  
+  // Called when user cancels document edit
   onCancelEdit?: () => void
   confirmCancel?: boolean
   /**

--- a/packages/components/src/local/molecules/json-editor/types/props.d.ts
+++ b/packages/components/src/local/molecules/json-editor/types/props.d.ts
@@ -47,7 +47,7 @@ export default interface Props {
   /** current game time, used for initialising date-time controls */
   // NOTE: provide game date using `customiseTemplate` helper. This allows
   // you to specify the default value in the schema, rather than the document itself
-  // in that way - validation can be applied to the field - forcing the user 
+  // in that way - validation can be applied to the field - forcing the user
   // to enter dates
   gameDate?: string
   /** disable/enable Array tools with form */

--- a/packages/components/src/local/molecules/json-editor/types/props.d.ts
+++ b/packages/components/src/local/molecules/json-editor/types/props.d.ts
@@ -45,7 +45,11 @@ export default interface Props {
    */
   clearForm?: boolean
   /** current game time, used for initialising date-time controls */
-  gameDate: string
+  // NOTE: provide game date using `customiseTemplate` helper. This allows
+  // you to specify the default value in the schema, rather than the document itself
+  // in that way - validation can be applied to the field - forcing the user 
+  // to enter dates
+  gameDate?: string
   /** disable/enable Array tools with form */
   disableArrayToolsWithEditor?: boolean
   formClassName?: string

--- a/packages/components/src/local/organisms/adjudication-messages-list/index.tsx
+++ b/packages/components/src/local/organisms/adjudication-messages-list/index.tsx
@@ -711,7 +711,6 @@ export const AdjudicationMessagesList: React.FC<PropTypes> = ({
               messageId={rowData.id}
               disabled={isComplete}
               template={template}
-              gameDate={gameDate}
               saveMessage={localSubmitAdjudication}
               storeNewValue={localStoreNewValue}
               onLocationEditorLoaded={onLocationEditorLoaded}

--- a/packages/components/src/local/organisms/planning-assets/index.tsx
+++ b/packages/components/src/local/organisms/planning-assets/index.tsx
@@ -59,9 +59,9 @@ export const PlanningAssets: React.FC<PropTypes> = ({
       // BIG PICTURE: for columns that have a filter, we will ensure it contains the full set of possible values for
       // that column, so the user can expand the selection.  But, if the column does not have a filter applied,
       // then restrict it to current values in the dataset.
-      console.time('get columns')
+      // console.time('get columns')
       const allColumns = getColumns(opFor, forces, playerForce.uniqid, platformStyles, assetsCache)
-      console.timeEnd('get columns')
+      // console.timeEnd('get columns')
       // const cached = cachedColumns
       // // see if any filters have been relaxed. If they have, we need to relax the filters in other columns
       // const relaxedColumns = columns.filter((column) => {

--- a/packages/components/src/local/organisms/planning-channel/index.tsx
+++ b/packages/components/src/local/organisms/planning-channel/index.tsx
@@ -270,7 +270,7 @@ export const PlanningChannel: React.FC<PropTypes> = ({
 
   useEffect(() => {
     // collate data
-    console.log('timeline interaction')
+    // console.log('timeline interaction')
     // update state
   }, [timelineInteractions])
 

--- a/packages/components/src/local/organisms/planning-force/index.tsx
+++ b/packages/components/src/local/organisms/planning-force/index.tsx
@@ -4,7 +4,6 @@ import L, { LatLng, latLng, LeafletMouseEvent, MarkerCluster, MarkerClusterGroup
 import 'leaflet.markercluster/dist/leaflet.markercluster'
 import 'leaflet.markercluster/dist/MarkerCluster.css'
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css'
-import moment from 'moment'
 import React, { useContext, useEffect, useState } from 'react'
 import * as ReactDOMServer from 'react-dom/server'
 import { Circle, LayerGroup, Marker, Tooltip, useMap } from 'react-leaflet-v4'
@@ -241,7 +240,7 @@ const PlanningForces: React.FC<PropTypes> = ({
       }
     }
 
-    asset.id === 'Blue.6.94' && console.log('Debug. Rendering clustered marker id', asset.id, moment().toISOString())
+    // asset.id === 'Blue.6.94' && console.log('Debug. Rendering clustered marker id', asset.id, moment().toISOString())
 
     return (
       L.marker(new L.LatLng(loc.lat, loc.lng),

--- a/packages/components/src/local/organisms/planning-messages-list/index.spec.tsx
+++ b/packages/components/src/local/organisms/planning-messages-list/index.spec.tsx
@@ -54,8 +54,7 @@ describe('ChannelMessagesList component: ', () => {
 
     const tree = renderer
       .create(<PlanningMessagesList selectedForce={blueForce} selectedRoleName={blueRole.name}
-        currentTurn={P9Mock.gameTurn} gameDate={P9Mock.data.overview.gameDate}
-        gameTurnEndDate={turnEndDate} channel={planningChannel}
+        currentTurn={P9Mock.gameTurn} gameTurnEndDate={turnEndDate} channel={planningChannel}
         hideForcesInChannel={false} selectedOrders={[]} setSelectedOrders={(): any => noop}
         messages={messages} onRead={undefined} onUnread={undefined} isUmpire={true} playerRoleId={blueRole.roleId}
         phase={Phase.Planning} editLocation={noop} onMarkAllAsRead={markAllAsRead} onSupportPanelLayoutChange={noop} />, {

--- a/packages/components/src/local/organisms/planning-messages-list/index.stories-inc.tsx
+++ b/packages/components/src/local/organisms/planning-messages-list/index.stories-inc.tsx
@@ -155,7 +155,6 @@ const Template: Story<MessageListPropTypes> = (args) => {
     messages={newestMessages}
     channel={planningChannel}
     customiseTemplate={localCustomiseTemplate}
-    gameDate={P9BMock.data.overview.gameDate}
     gameTurnEndDate={turnEndDate}
     allTemplates={templates}
     playerRoleId={role.roleId}

--- a/packages/components/src/local/organisms/planning-messages-list/index.tsx
+++ b/packages/components/src/local/organisms/planning-messages-list/index.tsx
@@ -36,7 +36,7 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
   const [visibleRows, setVisibleRows] = useState<OrderRow[]>([])
 
   const [pendingLocationData] = useState<Array<PlannedActivityGeometry[]>>([])
-  
+
   const [pendingMessages, setPendingMessages] = useState<MessagePlanning[]>([])
   const [updateMessages, setUpdateMessages] = useState<boolean>(false)
 
@@ -57,7 +57,7 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
       setUpdateMessages(false)
       const myForceMessages = messages.filter((message: MessagePlanning) => isUmpire || message.details.from.forceId === selectedForce.uniqid)
       const showOrdersForAllRoles = !onlyShowMyOrders
-      const myRoleMessages = myForceMessages.filter((message: MessagePlanning) => showOrdersForAllRoles || message.details.from.roleId === playerRoleId)      
+      const myRoleMessages = myForceMessages.filter((message: MessagePlanning) => showOrdersForAllRoles || message.details.from.roleId === playerRoleId)
       setMyMessages(myRoleMessages)
       setPendingMessages([])
     }

--- a/packages/components/src/local/organisms/planning-messages-list/index.tsx
+++ b/packages/components/src/local/organisms/planning-messages-list/index.tsx
@@ -53,6 +53,7 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
   }, [])
 
   useEffect(() => {
+    console.log('PlanningMessageList - update messages', updateMessages)
     if (updateMessages && pendingMessages.length) {
       // check there are no rows open
       const inEdit = visibleRows.find((row) => {
@@ -63,13 +64,14 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
         return false
       })
       if (!inEdit) {
-        setUpdateMessages(false)
-        const myForceMessages = messages.filter((message: MessagePlanning) => isUmpire || message.details.from.forceId === selectedForce.uniqid)
-        const showOrdersForAllRoles = !onlyShowMyOrders
-        const myRoleMessages = myForceMessages.filter((message: MessagePlanning) => showOrdersForAllRoles || message.details.from.roleId === playerRoleId)
-        setMyMessages(myRoleMessages)
+        console.log('PlanningMessageList = update pending', pendingMessages.length)
+        setMyMessages(pendingMessages)
         setPendingMessages([])
+      } else {
+        console.log('PlanningMessageList - not doing edit, row open')
       }
+      // clear the flag, else we won't get triggered on the next row collapse
+      setUpdateMessages(false)
     }
   }, [pendingMessages, updateMessages, visibleRows])
 
@@ -145,7 +147,7 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
 
   // useEffect hook serves asynchronously, whereas the useLayoutEffect hook works synchronously
   useLayoutEffect(() => {
-    console.log('PlanningMessageList update:', myMessages.length, myMessages.length && myMessages[0].message.title)
+    console.log('PlanningMessageList update messages:', myMessages.length, myMessages.length && myMessages[0].message.title)
     const dataTable: OrderRow[] = myMessages.map((message) => {
       return toRow(message)
     })

--- a/packages/components/src/local/organisms/planning-messages-list/index.tsx
+++ b/packages/components/src/local/organisms/planning-messages-list/index.tsx
@@ -85,7 +85,7 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
       //   return false
       // })
       const inEdit = (messageValue.current !== '') && (messageValue.current !== null)
-      console.log('inEdit', inEdit, messageValue.current)
+      console.log('inEdit', inEdit, messageValue.current, visibleRows.length)
       if (inEdit) {
         // a message is expanded. Don't update the UI - store the pending change
         console.log('PlanningMessageList = update 3 - store pending messages', myRoleMessages.length)

--- a/packages/components/src/local/organisms/planning-messages-list/index.tsx
+++ b/packages/components/src/local/organisms/planning-messages-list/index.tsx
@@ -4,6 +4,7 @@ import MaterialTable, { Action, Column, MTableBody } from '@material-table/core'
 import { Phase, SUPPORT_PANEL_LAYOUT } from '@serge/config'
 import { MessageDetails, MessagePlanning, PerForcePlanningActivitySet, PlannedActivityGeometry, PlanningMessageStructure, TemplateBody } from '@serge/custom-types'
 import cx from 'classnames'
+import { isEqual } from 'lodash'
 import moment from 'moment'
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import CustomDialog from '../../atoms/custom-dialog'
@@ -18,7 +19,7 @@ import styles from './styles.module.scss'
 import PropTypes, { OrderRow } from './types/props'
 
 export const PlanningMessagesList: React.FC<PropTypes> = ({
-  messages, allTemplates, isUmpire, gameDate, customiseTemplate,
+  messages, allTemplates, isUmpire, customiseTemplate,
   playerRoleId, selectedOrders, postBack, postBackArchive, setSelectedOrders,
   confirmCancel, channel, selectedForce, selectedRoleName, currentTurn, turnFilter,
   editLocation, forcePlanningActivities, onDetailPanelOpen, onDetailPanelClose,
@@ -38,7 +39,6 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
   const [pendingLocationData] = useState<Array<PlannedActivityGeometry[]>>([])
 
   const [pendingMessages, setPendingMessages] = useState<MessagePlanning[]>([])
-  const [updateMessages, setUpdateMessages] = useState<boolean>(false)
   const [messageBeingEdited, setMessageBeingEdited] = useState<boolean>(false)
 
   if (selectedForce === undefined) { throw new Error('selectedForce is undefined') }
@@ -54,8 +54,7 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
   }, [])
 
   useEffect(() => {
-    console.log('PlanningMessageList - update messages', updateMessages, messageBeingEdited)
-    if (updateMessages && pendingMessages.length) {
+    if (pendingMessages.length) {
       // check there are no rows open
       if (!messageBeingEdited) {
         console.log('PlanningMessageList = update pending', pendingMessages.length)
@@ -64,10 +63,8 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
       } else {
         console.log('PlanningMessageList - not doing edit, message being edited')
       }
-      // clear the flag, else we won't get triggered on the next row collapse
-      setUpdateMessages(false)
     }
-  }, [pendingMessages, updateMessages, visibleRows, messageBeingEdited])
+  }, [pendingMessages, visibleRows, messageBeingEdited])
 
   useEffect(() => {
     const myForceMessages = messages.filter((message: MessagePlanning) => isUmpire || message.details.from.forceId === selectedForce.uniqid)
@@ -144,14 +141,16 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
   }, [turnFilter, filter, myMessages])
 
   const editorValue = (val: { [property: string]: any }): void => {
+    if (!isEqual(val, messageValue.current)) {
+      // new value is different from stored one. Record message as being edited.
+      setMessageBeingEdited(true)
+    }
     messageValue.current = val
-    setMessageBeingEdited(true)
   }
 
   const onLocalDetailPanelClose = (rowData: OrderRow) => {
     setMessageBeingEdited(false)
     onDetailPanelClose && onDetailPanelClose(rowData)
-    setUpdateMessages(true)
   }
 
   const detailPanel = ({ rowData }: { rowData: OrderRow }): any => {
@@ -211,16 +210,13 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
               while (pendingLocationData.length) { pendingLocationData.pop() }
             }
 
+            postBack && postBack(details, messageValue.current)
+            // messageValue.current = ''
+
             // this document is being saved. Cause page update without checking for open rows,
             // so that we display updated document
             console.log('PlanningMessageList = about to clear only update flag')
             setMessageBeingEdited(false)
-
-            postBack && postBack(details, messageValue.current)
-            messageValue.current = ''
-
-            // trigger load of any pending messages  
-            setUpdateMessages(true)
           }
         }
 
@@ -264,7 +260,6 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
             confirmCancel={confirmCancel}
             template={template}
             disabled={!canEdit}
-            gameDate={gameDate}
             modifyForEdit={(document) => collapseLocation(document, activitiesForThisForce)}
             modifyForSave={modifyForSave}
             editCallback={localEditLocation}
@@ -295,7 +290,6 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
 
         return archivedMessage
       })
-      console.log('Archiving:', markArchived)
       postBackArchive && postBackArchive(markArchived)
       setPendingArchive([])
     }

--- a/packages/components/src/local/organisms/planning-messages-list/index.tsx
+++ b/packages/components/src/local/organisms/planning-messages-list/index.tsx
@@ -220,6 +220,10 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
           }
         }
 
+        const onCancelEdit = () => {
+          setMessageBeingEdited(false)
+        }
+
         const localEditLocation = (): void => {
           if (message.message.location) {
             const localCallback = (newValue: PlannedActivityGeometry[]): void => {
@@ -254,6 +258,7 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
             messageContent={editorRightValue}
             viewSaveButton={true}
             saveMessage={saveMessage}
+            onCancelEdit={onCancelEdit}
             customiseTemplate={customiseTemplate}
             storeNewValue={editorValue}
             messageId={rowData.id}

--- a/packages/components/src/local/organisms/planning-messages-list/index.tsx
+++ b/packages/components/src/local/organisms/planning-messages-list/index.tsx
@@ -1,6 +1,6 @@
 import { faSearchMinus, faSearchPlus, faTrashAlt, faUser, faUserLock } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import MaterialTable, { Action, Column } from '@material-table/core'
+import MaterialTable, { Action, Column, MTableBody } from '@material-table/core'
 import { Phase, SUPPORT_PANEL_LAYOUT } from '@serge/config'
 import { MessageDetails, MessagePlanning, PerForcePlanningActivitySet, PlannedActivityGeometry, PlanningMessageStructure, TemplateBody } from '@serge/custom-types'
 import cx from 'classnames'
@@ -33,8 +33,12 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
   const messageValue = useRef<any>(null)
   const [pendingArchive, setPendingArchive] = useState<OrderRow[]>([])
   const [toolbarActions, setToolbarActions] = useState<Action<OrderRow>[]>([])
+  const [visibleRows, setVisibleRows] = useState<OrderRow[]>([])
 
   const [pendingLocationData] = useState<Array<PlannedActivityGeometry[]>>([])
+  
+  const [pendingMessages, setPendingMessages] = useState<MessagePlanning[]>([])
+  const [updateMessages, setUpdateMessages] = useState<boolean>(false)
 
   if (selectedForce === undefined) { throw new Error('selectedForce is undefined') }
   !7 && console.log('planning selectedOrders: ', selectedOrders, !!setSelectedOrders, messages.length)
@@ -48,6 +52,19 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
     }
   }, [])
 
+  console.log('pending', pendingMessages.length, updateMessages)
+
+  useEffect(() => {
+    if (updateMessages && pendingMessages.length) {
+      setUpdateMessages(false)
+      const myForceMessages = messages.filter((message: MessagePlanning) => isUmpire || message.details.from.forceId === selectedForce.uniqid)
+      const showOrdersForAllRoles = !onlyShowMyOrders
+      const myRoleMessages = myForceMessages.filter((message: MessagePlanning) => showOrdersForAllRoles || message.details.from.roleId === playerRoleId)      
+      setMyMessages(myRoleMessages)
+      setPendingMessages([])
+    }
+  }, [pendingMessages, updateMessages])
+
   useEffect(() => {
     const myForceMessages = messages.filter((message: MessagePlanning) => isUmpire || message.details.from.forceId === selectedForce.uniqid)
     const showOrdersForAllRoles = !onlyShowMyOrders
@@ -59,22 +76,20 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
       // no messages, clear list
       setMyMessages([])
     } else {
-      // Note: we have an issue here.  If the player filters their orders, then we'll have a reduced set of orders
-      // Note: but, the processing below will just inject the newest message.
-      // Note: I "think" we only do this following processing if the new messages is one longer than the previous list, and that
-      // Note: the first message has the reference of an existing message
-      const newMessage = myRoleMessages[0]
-      // see if this is a new version of an existing message
-      const rowAlreadyPresent = rows.find((row) => row.reference === newMessage.message.Reference)
-      if (rowAlreadyPresent && rowAlreadyPresent.id !== newMessage._id) {
-        // ok, it's an update
-        // remove the previous instance of the updated message
-        const otherMessage = rows.filter(findeIndex => !findeIndex.reference.includes(newMessage.message.Reference))
-        const row = toRow(newMessage)
-        // push a new row
-        setRows([...otherMessage, row])
+      // see if any rows are expanded
+      const inEdit = visibleRows.find((row) => {
+        const rowAny = row as any
+        if (rowAny.tableData && rowAny.tableData.showDetailPanel) {
+          return true
+        }
+        return false
+      })
+      if (inEdit) {
+        // a message is expanded. Don't update the UI - store the pending change
+        console.log('Planning Messages List - store pending messages', myRoleMessages.length)
+        setPendingMessages(myRoleMessages)
       } else {
-        // first row isn't an existing one
+        console.log('Planning Messages List - update messages')
         setMyMessages(myRoleMessages)
       }
     }
@@ -133,9 +148,10 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
     messageValue.current = val
   }
 
-  // const editDocument = (docId: string): void => {
-  //   editThisMessage && editThisMessage(docId)
-  // }
+  const onLocalDetailPanelClose = (rowData: OrderRow) => {
+    onDetailPanelClose && onDetailPanelClose(rowData)
+    setUpdateMessages(true)
+  }
 
   const detailPanel = ({ rowData }: { rowData: OrderRow }): any => {
     // retrieve the message & template
@@ -195,6 +211,8 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
             }
             postBack && postBack(details, messageValue.current)
             messageValue.current = ''
+
+            setUpdateMessages(true)
           }
         }
 
@@ -214,7 +232,7 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
           useEffect(() => {
             onDetailPanelOpen && onDetailPanelOpen(rowData)
             return () => {
-              onDetailPanelClose && onDetailPanelClose(rowData)
+              onLocalDetailPanelClose(rowData)
             }
           }, [])
           return <></>
@@ -252,7 +270,6 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
 
   /*eslint-disable */
   const archiveConfirmed = (): void => {
-    console.log('confirmed. Pending:', pendingArchive)
     if (pendingArchive) {
       const actualMessages = pendingArchive.map((row): MessagePlanning | undefined => messages.find((msg) => msg.message.Reference === row.rawRef))
       if (actualMessages.length !== pendingArchive.length) {
@@ -281,7 +298,6 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
 
   const archiveSelected = (data: OrderRow | OrderRow[]): void => {
     const rows: OrderRow[] = Array.isArray(data) ? data : [data]
-    console.log('Request to archive', rows)
     setPendingArchive(rows)
   }
 
@@ -309,6 +325,16 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
       onSelectionChange={onSelectionChange}
       detailPanel={detailPanel}
       components={{
+        Body: (props): React.ReactElement => {
+          if (props.columns.length) {
+            setTimeout(() => {
+              setVisibleRows(props.data)
+            })
+          }
+          return (<MTableBody
+            {...props}
+          />)
+        },
         FilterRow: props => <CustomFilterRow {...props} forces={[]} onSupportPanelLayoutChange={onSupportPanelLayoutChange} cacheKey={TAB_MY_ORDERS} />
       }}
     />

--- a/packages/components/src/local/organisms/planning-messages-list/index.tsx
+++ b/packages/components/src/local/organisms/planning-messages-list/index.tsx
@@ -68,7 +68,7 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
         const showOrdersForAllRoles = !onlyShowMyOrders
         const myRoleMessages = myForceMessages.filter((message: MessagePlanning) => showOrdersForAllRoles || message.details.from.roleId === playerRoleId)
         setMyMessages(myRoleMessages)
-        setPendingMessages([])  
+        setPendingMessages([])
       }
     }
   }, [pendingMessages, updateMessages, visibleRows])
@@ -94,7 +94,7 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
         }
         return false
       })
-//      const inEdit = (messageValue.current !== '') && (messageValue.current !== null)
+      //      const inEdit = (messageValue.current !== '') && (messageValue.current !== null)
       console.log('inEdit', inEdit)
       if (inEdit) {
         // a message is expanded. Don't update the UI - store the pending change

--- a/packages/components/src/local/organisms/planning-messages-list/index.tsx
+++ b/packages/components/src/local/organisms/planning-messages-list/index.tsx
@@ -54,14 +54,24 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
 
   useEffect(() => {
     if (updateMessages && pendingMessages.length) {
-      setUpdateMessages(false)
-      const myForceMessages = messages.filter((message: MessagePlanning) => isUmpire || message.details.from.forceId === selectedForce.uniqid)
-      const showOrdersForAllRoles = !onlyShowMyOrders
-      const myRoleMessages = myForceMessages.filter((message: MessagePlanning) => showOrdersForAllRoles || message.details.from.roleId === playerRoleId)
-      setMyMessages(myRoleMessages)
-      setPendingMessages([])
+      // check there are no rows open
+      const inEdit = visibleRows.find((row) => {
+        const rowAny = row as any
+        if (rowAny.tableData && rowAny.tableData.showDetailPanel) {
+          return true
+        }
+        return false
+      })
+      if (!inEdit) {
+        setUpdateMessages(false)
+        const myForceMessages = messages.filter((message: MessagePlanning) => isUmpire || message.details.from.forceId === selectedForce.uniqid)
+        const showOrdersForAllRoles = !onlyShowMyOrders
+        const myRoleMessages = myForceMessages.filter((message: MessagePlanning) => showOrdersForAllRoles || message.details.from.roleId === playerRoleId)
+        setMyMessages(myRoleMessages)
+        setPendingMessages([])  
+      }
     }
-  }, [pendingMessages, updateMessages])
+  }, [pendingMessages, updateMessages, visibleRows])
 
   useEffect(() => {
     const myForceMessages = messages.filter((message: MessagePlanning) => isUmpire || message.details.from.forceId === selectedForce.uniqid)
@@ -77,15 +87,15 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
       setMyMessages([])
     } else {
       // // see if any rows are expanded
-      // const inEdit = visibleRows.find((row) => {
-      //   const rowAny = row as any
-      //   if (rowAny.tableData && rowAny.tableData.showDetailPanel) {
-      //     return true
-      //   }
-      //   return false
-      // })
-      const inEdit = (messageValue.current !== '') && (messageValue.current !== null)
-      console.log('inEdit', inEdit, messageValue.current, visibleRows.length)
+      const inEdit = visibleRows.find((row) => {
+        const rowAny = row as any
+        if (rowAny.tableData && rowAny.tableData.showDetailPanel) {
+          return true
+        }
+        return false
+      })
+//      const inEdit = (messageValue.current !== '') && (messageValue.current !== null)
+      console.log('inEdit', inEdit)
       if (inEdit) {
         // a message is expanded. Don't update the UI - store the pending change
         console.log('PlanningMessageList = update 3 - store pending messages', myRoleMessages.length)

--- a/packages/components/src/local/organisms/planning-messages-list/index.tsx
+++ b/packages/components/src/local/organisms/planning-messages-list/index.tsx
@@ -52,8 +52,6 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
     }
   }, [])
 
-  console.log('pending', pendingMessages.length, updateMessages)
-
   useEffect(() => {
     if (updateMessages && pendingMessages.length) {
       setUpdateMessages(false)
@@ -70,25 +68,30 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
     const showOrdersForAllRoles = !onlyShowMyOrders
     const myRoleMessages = myForceMessages.filter((message: MessagePlanning) => showOrdersForAllRoles || message.details.from.roleId === playerRoleId)
     if (myMessages.length === 0) {
+      console.log('PlanningMessageList = update 1')
       // initial load, just load them
       setMyMessages(myRoleMessages)
     } else if (myRoleMessages.length === 0) {
+      console.log('PlanningMessageList = update 2')
       // no messages, clear list
       setMyMessages([])
     } else {
-      // see if any rows are expanded
-      const inEdit = visibleRows.find((row) => {
-        const rowAny = row as any
-        if (rowAny.tableData && rowAny.tableData.showDetailPanel) {
-          return true
-        }
-        return false
-      })
+      // // see if any rows are expanded
+      // const inEdit = visibleRows.find((row) => {
+      //   const rowAny = row as any
+      //   if (rowAny.tableData && rowAny.tableData.showDetailPanel) {
+      //     return true
+      //   }
+      //   return false
+      // })
+      const inEdit = (messageValue.current !== '') && (messageValue.current !== null)
+      console.log('inEdit', inEdit, messageValue.current)
       if (inEdit) {
         // a message is expanded. Don't update the UI - store the pending change
-        console.log('Planning Messages List - store pending messages', myRoleMessages.length)
+        console.log('PlanningMessageList = update 3 - store pending messages', myRoleMessages.length)
         setPendingMessages(myRoleMessages)
       } else {
+        console.log('PlanningMessageList = update 4')
         console.log('Planning Messages List - update messages')
         setMyMessages(myRoleMessages)
       }
@@ -132,6 +135,7 @@ export const PlanningMessagesList: React.FC<PropTypes> = ({
 
   // useEffect hook serves asynchronously, whereas the useLayoutEffect hook works synchronously
   useLayoutEffect(() => {
+    console.log('PlanningMessageList update:', myMessages.length, myMessages.length && myMessages[0].message.title)
     const dataTable: OrderRow[] = myMessages.map((message) => {
       return toRow(message)
     })

--- a/packages/components/src/local/organisms/planning-messages-list/types/props.d.ts
+++ b/packages/components/src/local/organisms/planning-messages-list/types/props.d.ts
@@ -27,10 +27,6 @@ export default interface PropTypes extends Omit<ForcesInChannelProps, 'icons' | 
    */
   messages: Array<MessagePlanning>
   /**
-   *  current game-date (may be used in JSON Editor for date-picker)
-   */
-  gameDate: string
-  /**
    *  current date for turn-end (may be used for finding other orders to sync iwth)
    */
   gameTurnEndDate: string

--- a/packages/components/src/local/organisms/support-panel/index.tsx
+++ b/packages/components/src/local/organisms/support-panel/index.tsx
@@ -134,7 +134,6 @@ export const SupportPanel: React.FC<PropTypes> = ({
       const endDate = incrementGameTime(gameDate, gameTurnTime)
       setGameTurnEndDate(endDate)
     }
-    setLocalDraftMessage(draftMessage)
   }, [gameDate, gameTurnTime])
 
   useEffect(() => {
@@ -236,6 +235,7 @@ export const SupportPanel: React.FC<PropTypes> = ({
   }
 
   const postBack = (details: MessageDetails, message: any): void => {
+    console.log('SupportPanel - save message postack', message.Reference)
     // do we have any pending geometry
     if (pendingLocationData.length > 0) {
       const plan = message as MessagePlanning
@@ -278,7 +278,7 @@ export const SupportPanel: React.FC<PropTypes> = ({
         const endD = moment(endDate)
         return startD.isBefore(turnEnd) && endD.isAfter(turnStart)
       } else {
-        console.log('Support panel. Orders start/end missing, so cannot offer for live orders', plan.message.Reference, plan)
+        // console.log('Support panel. Orders start/end missing, so cannot offer for live orders', plan.message.Reference, plan)
         return true
       }
     })

--- a/packages/components/src/local/organisms/support-panel/index.tsx
+++ b/packages/components/src/local/organisms/support-panel/index.tsx
@@ -485,7 +485,6 @@ export const SupportPanel: React.FC<PropTypes> = ({
                 <TurnFilter label='Show orders for turn:' allPeriods={allPeriods} value={turnFilter} onChange={onTurnFilterChange} />
                 <PlanningMessagesList
                   messages={filteredPlanningMessages}
-                  gameDate={gameDate}
                   phase={phase}
                   gameTurnEndDate={gameTurnEndDate}
                   playerRoleId={selectedRoleId}

--- a/packages/helpers/src/geometry-helpers.ts
+++ b/packages/helpers/src/geometry-helpers.ts
@@ -15,7 +15,7 @@ const updateLeg = (leg: PlannedActivityGeometry, startT: number, endT: number, s
 
     // mangle the millis, to make things work, if necessary
     if (millis < millisRemaining) {
-      console.warn('Will have to trim millis to fit in time period')
+      console.warn('Will have to trim millis to fit in time period', leg.uniqid)
     }
     const safeMillis = millis < millisRemaining ? millis : millisRemaining / 2
 


### PR DESCRIPTION
The issue of losing form contents has returned, #2141 

The initial part of the problem was that `row.reference` no longer contained the message reference, it was a composite field containing reference and turn.

But, after fixing that is was still broken.

So, I started on a strategy of not updating the <PlanningMessagesList> if a message was being edited, and stored the updates for when the message was saved, or the row collapsed.