### PR TITLE
Serge Admin Issues

### DIFF
--- a/packages/client/src/ActionsAndReducers/dbWargames/wargames_ActionCreators.ts
+++ b/packages/client/src/ActionsAndReducers/dbWargames/wargames_ActionCreators.ts
@@ -408,7 +408,7 @@ export const deleteSelectedRole = (
 ) => {
   return async (dispatch: WargameDispatch) => {
     const wargame = await wargamesApi.deleteRolesParticipations(dbName, data.roles, data.key)
-    _.isArray(wargame) ? await data.handleChange(wargame) : dispatch(setCurrentWargame(wargame))
+    _.isArray(wargame) ? data.handleChange(wargame) : dispatch(setCurrentWargame(wargame))
     dispatch(addNotification('Role deleted.', 'warning'))
   }
 }

--- a/packages/client/src/ActionsAndReducers/playerUi/helpers/handleWargameMessagesChange.ts
+++ b/packages/client/src/ActionsAndReducers/playerUi/helpers/handleWargameMessagesChange.ts
@@ -52,7 +52,7 @@ export const handleNewMessage = (payload: MessageChannel, newState: PlayerUi): S
 export const handleSetAllMessages = (payload: Array<MessageCustom | MessageInfoType>, newState: PlayerUi): SetWargameMessage => {
   const res: SetWargameMessage = handleAllInitialChannelMessages(payload, newState.currentWargame, newState.selectedForce,
     newState.selectedRole, newState.allChannels, newState.allForces, newState.chatChannel,
-    newState.isObserver, newState.allTemplatesByKey)
+    newState.isObserver, newState.allTemplatesByKey, newState.isUmpire)
   return res
 }
 

--- a/packages/components/src/local/molecules/password-view/__snapshots__/index.spec.tsx.snap
+++ b/packages/components/src/local/molecules/password-view/__snapshots__/index.spec.tsx.snap
@@ -3,35 +3,8 @@
 exports[`password-view renders correctly 1`] = `
 <div
   className="main"
-  title="Click to Copy or Edit"
+  title="Click to Edit"
 >
-  <section
-    className="input-container disable-offset"
-  >
-    <div
-      className="MuiFormControl-root MuiTextField-root"
-    >
-      <div
-        className="MuiInputBase-root MuiInput-root makeStyles-root-4 makeStyles-root-6 MuiInput-underline makeStyles-underline-5 makeStyles-underline-7 MuiInputBase-formControl MuiInput-formControl"
-        onClick={[Function]}
-      >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
-          disabled={false}
-          name=""
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          required={false}
-          type="text"
-          value=""
-        />
-      </div>
-    </div>
-  </section>
   <section
     className="password-mask"
   >
@@ -41,6 +14,7 @@ exports[`password-view renders correctly 1`] = `
   </section>
   <div
     className="key"
+    onClick={[Function]}
   >
     <svg
       className="svg-inline--fa fa-key"

--- a/packages/components/src/local/molecules/password-view/index.tsx
+++ b/packages/components/src/local/molecules/password-view/index.tsx
@@ -1,36 +1,35 @@
-import React from 'react'
+import { faCircle, faKey } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faKey, faCircle } from '@fortawesome/free-solid-svg-icons'
-
-/* Import proptypes */
+import React, { useState } from 'react'
+import TextInput from '../../atoms/text-input'
+import styles from './styles.module.scss'
 import PropTypes from './types/props'
 
-/* Import Styles */
-import styles from './styles.module.scss'
-
-/* Import Components */
-import TextInput from '../../atoms/text-input'
-
-/* Render component */
 export const PasswordView: React.FC<PropTypes> = ({ value, onChange }) => {
+  const [edit, setEdit] = useState<boolean>(false)
+
+  const makeEdit = () => {
+    setEdit(!edit)
+  }
+
   return (
-    <div className={styles.main} title='Click to Copy or Edit'>
-      <TextInput
+    <div className={styles.main} title='Click to Edit'>
+      {edit && <TextInput
         customColor="transparent"
         value={value || ''}
-        updateState={(target: {value: string}): void => {
+        updateState={(target: { value: string }): void => {
           onChange(target.value)
         }}
-      />
-      <section className={styles['password-mask']}>
+      />}
+      {!edit && <section className={styles['password-mask']}>
         <div className={styles.dots}>
           {[...Array((value || '').length)].map((_e, i) => (
             <FontAwesomeIcon icon={faCircle} key={i} size='xs' />
           ))}
         </div>
-      </section>
-      <div className={styles.key}>
-        <FontAwesomeIcon icon={faKey} />
+      </section>}
+      <div className={styles.key} onClick={makeEdit}>
+        <FontAwesomeIcon icon={faKey}/>
       </div>
     </div>
   )

--- a/packages/components/src/local/molecules/password-view/styles.module.scss
+++ b/packages/components/src/local/molecules/password-view/styles.module.scss
@@ -34,25 +34,9 @@
     font-size: inherit;
     line-height: inherit;
     display: block;
-    opacity: 0;
     font-weight: bold;
     padding: 4px;
   }
-}
-
-.main:hover input {
-  opacity: 1;
-}
-.main:hover .password-mask {
-  display: none;
-}
-
-.main input:focus {
-  opacity: 1;
-}
-
-.main [class*="input-container--focused"] + .password-mask {
-  display: none;
 }
 
 .dots {
@@ -77,4 +61,5 @@
   align-items: center;
   justify-content: center;
   width: 30px;
+  z-index: 1111;
 }

--- a/packages/components/src/local/molecules/sortable-list/index.tsx
+++ b/packages/components/src/local/molecules/sortable-list/index.tsx
@@ -116,7 +116,7 @@ export const SortableList: React.FC<PropTypes> = React.forwardRef(({
       const newValueFilled: boolean = `${newValue}`.length > 0
       if (required) {
         if (!newValueFilled) {
-          if (valueOnEmpty) {
+          if (valueOnEmpty !== null && valueOnEmpty !== undefined) {
             newValue = valueOnEmpty
           } else {
             newValue = getValue(items[key])
@@ -127,7 +127,7 @@ export const SortableList: React.FC<PropTypes> = React.forwardRef(({
 
       const newItems: Array<Item> = [...items]
       if (typeof item === 'object') {
-        if (newItems[key] && item.name) {
+        if (newItems[key]) {
           newItems[key] = { ...item as ItemObject, name: newValue } as ItemObject
         }
       } else {

--- a/packages/components/src/local/molecules/sortable-list/styles.module.scss
+++ b/packages/components/src/local/molecules/sortable-list/styles.module.scss
@@ -41,6 +41,10 @@
   flex-direction: row;
   align-items: center;
   min-width: 25%;
+  div {
+    min-width: 100%;
+    min-height: 25px;
+  }
 }
 
 .main li {

--- a/packages/components/src/local/molecules/sortable-list/styles.module.scss
+++ b/packages/components/src/local/molecules/sortable-list/styles.module.scss
@@ -31,11 +31,6 @@
   opacity: 1;
 }
 
-.active section,
-.main li:hover section {
-  border-bottom: 1px solid #434343 !important;
-}
-
 .value-label {
   display: flex;
   flex-direction: row;

--- a/packages/components/src/local/organisms/setting-forces/__snapshots__/index.spec.tsx.snap
+++ b/packages/components/src/local/organisms/setting-forces/__snapshots__/index.spec.tsx.snap
@@ -542,35 +542,8 @@ exports[`SettingForces component: renders correctly 1`] = `
                                           >
                                             <div
                                               className="main"
-                                              title="Click to Copy or Edit"
+                                              title="Click to Edit"
                                             >
-                                              <section
-                                                className="input-container disable-offset"
-                                              >
-                                                <div
-                                                  className="MuiFormControl-root MuiTextField-root"
-                                                >
-                                                  <div
-                                                    className="MuiInputBase-root MuiInput-root makeStyles-root-4 makeStyles-root-17 MuiInput-underline makeStyles-underline-5 makeStyles-underline-18 MuiInputBase-formControl MuiInput-formControl"
-                                                    onClick={[Function]}
-                                                  >
-                                                    <input
-                                                      aria-invalid={false}
-                                                      autoFocus={false}
-                                                      className="MuiInputBase-input MuiInput-input"
-                                                      disabled={false}
-                                                      name=""
-                                                      onAnimationStart={[Function]}
-                                                      onBlur={[Function]}
-                                                      onChange={[Function]}
-                                                      onFocus={[Function]}
-                                                      required={false}
-                                                      type="text"
-                                                      value="rkrlw6f5f"
-                                                    />
-                                                  </div>
-                                                </div>
-                                              </section>
                                               <section
                                                 className="password-mask"
                                               >
@@ -608,6 +581,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                               </section>
                                               <div
                                                 className="key"
+                                                onClick={[Function]}
                                               >
                                                 <svg
                                                   className="svg-inline--fa fa-key"
@@ -628,7 +602,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                             >
                                               <span
                                                 aria-disabled={false}
-                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-19 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-20"
+                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-17 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-18"
                                                 onBlur={[Function]}
                                                 onDragLeave={[Function]}
                                                 onFocus={[Function]}
@@ -661,7 +635,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                                 />
                                               </span>
                                               <span
-                                                className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-21"
+                                                className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-19"
                                               />
                                             </span>
                                             <div
@@ -681,7 +655,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                             >
                                               <span
                                                 aria-disabled={false}
-                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-19 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-20"
+                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-17 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-18"
                                                 onBlur={[Function]}
                                                 onDragLeave={[Function]}
                                                 onFocus={[Function]}
@@ -714,7 +688,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                                 />
                                               </span>
                                               <span
-                                                className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-21"
+                                                className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-19"
                                               />
                                             </span>
                                             <div
@@ -734,7 +708,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                             >
                                               <span
                                                 aria-disabled={false}
-                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-19 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-20"
+                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-17 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-18"
                                                 onBlur={[Function]}
                                                 onDragLeave={[Function]}
                                                 onFocus={[Function]}
@@ -767,7 +741,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                                 />
                                               </span>
                                               <span
-                                                className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-21"
+                                                className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-19"
                                               />
                                             </span>
                                             <div
@@ -787,7 +761,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                             >
                                               <span
                                                 aria-disabled={false}
-                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-19 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-20"
+                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-17 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-18"
                                                 onBlur={[Function]}
                                                 onDragLeave={[Function]}
                                                 onFocus={[Function]}
@@ -820,7 +794,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                                 />
                                               </span>
                                               <span
-                                                className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-21"
+                                                className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-19"
                                               />
                                             </span>
                                             <div
@@ -873,35 +847,8 @@ exports[`SettingForces component: renders correctly 1`] = `
                                           >
                                             <div
                                               className="main"
-                                              title="Click to Copy or Edit"
+                                              title="Click to Edit"
                                             >
-                                              <section
-                                                className="input-container disable-offset"
-                                              >
-                                                <div
-                                                  className="MuiFormControl-root MuiTextField-root"
-                                                >
-                                                  <div
-                                                    className="MuiInputBase-root MuiInput-root makeStyles-root-4 makeStyles-root-22 MuiInput-underline makeStyles-underline-5 makeStyles-underline-23 MuiInputBase-formControl MuiInput-formControl"
-                                                    onClick={[Function]}
-                                                  >
-                                                    <input
-                                                      aria-invalid={false}
-                                                      autoFocus={false}
-                                                      className="MuiInputBase-input MuiInput-input"
-                                                      disabled={false}
-                                                      name=""
-                                                      onAnimationStart={[Function]}
-                                                      onBlur={[Function]}
-                                                      onChange={[Function]}
-                                                      onFocus={[Function]}
-                                                      required={false}
-                                                      type="text"
-                                                      value="rkrlasdd5f"
-                                                    />
-                                                  </div>
-                                                </div>
-                                              </section>
                                               <section
                                                 className="password-mask"
                                               >
@@ -942,6 +889,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                               </section>
                                               <div
                                                 className="key"
+                                                onClick={[Function]}
                                               >
                                                 <svg
                                                   className="svg-inline--fa fa-key"
@@ -957,7 +905,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                             >
                                               <span
                                                 aria-disabled={false}
-                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-19 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-20"
+                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-17 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-18"
                                                 onBlur={[Function]}
                                                 onDragLeave={[Function]}
                                                 onFocus={[Function]}
@@ -990,7 +938,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                                 />
                                               </span>
                                               <span
-                                                className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-21"
+                                                className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-19"
                                               />
                                             </span>
                                           </div>
@@ -1002,7 +950,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                             >
                                               <span
                                                 aria-disabled={false}
-                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-19 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-20"
+                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-17 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-18"
                                                 onBlur={[Function]}
                                                 onDragLeave={[Function]}
                                                 onFocus={[Function]}
@@ -1035,7 +983,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                                 />
                                               </span>
                                               <span
-                                                className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-21"
+                                                className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-19"
                                               />
                                             </span>
                                           </div>
@@ -1047,7 +995,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                             >
                                               <span
                                                 aria-disabled={false}
-                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-19 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-20"
+                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-17 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-18"
                                                 onBlur={[Function]}
                                                 onDragLeave={[Function]}
                                                 onFocus={[Function]}
@@ -1080,7 +1028,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                                 />
                                               </span>
                                               <span
-                                                className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-21"
+                                                className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-19"
                                               />
                                             </span>
                                           </div>
@@ -1092,7 +1040,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                             >
                                               <span
                                                 aria-disabled={false}
-                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-19 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-20"
+                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-17 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-18"
                                                 onBlur={[Function]}
                                                 onDragLeave={[Function]}
                                                 onFocus={[Function]}
@@ -1125,7 +1073,7 @@ exports[`SettingForces component: renders correctly 1`] = `
                                                 />
                                               </span>
                                               <span
-                                                className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-21"
+                                                className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-19"
                                               />
                                             </span>
                                           </div>

--- a/packages/components/src/local/organisms/setting-forces/index.tsx
+++ b/packages/components/src/local/organisms/setting-forces/index.tsx
@@ -1,24 +1,21 @@
-import { Asset, AttributeType, AttributeValue } from '@serge/custom-types'
+import { Asset, AttributeType, AttributeValue, Role } from '@serge/custom-types'
 import { createAttributeValue, findPlatformTypeFor } from '@serge/helpers'
 import cx from 'classnames'
-import React, { useEffect, useState } from 'react'
-import { CustomDialog } from '../../atoms/custom-dialog'
-/* Import Components */
+import React, { useEffect, useRef, useState } from 'react'
 import { AdminContent, LeftSide, RightSide } from '../../atoms/admin-content'
 import Button from '../../atoms/button'
 import Colorpicker from '../../atoms/colorpicker'
+import Confirm from '../../atoms/confirm'
+import { CustomDialog } from '../../atoms/custom-dialog'
 import TextInput from '../../atoms/text-input'
 import EditableList, { Item } from '../../molecules/editable-list'
 import IconUploader from '../../molecules/icon-uploader'
 import SettingsForceOverview from './settings-force-overview'
 import AssetsAccordion from './settings-force-platform-types'
 import RolesAccordion from './settings-force-roles'
-/* Import Styles */
 import styles from './styles.module.scss'
-/* Import proptypes */
 import PropTypes, { ForceData } from './types/props'
 
-/* Render component */
 export const SettingForces: React.FC<PropTypes> = ({
   forces: initialForces,
   onSave,
@@ -39,10 +36,13 @@ export const SettingForces: React.FC<PropTypes> = ({
   const [selectedItem, setSelectedItem] = useState(Math.max(selectedForceId, 0))
   const [forcesData, setForcesData] = useState(initialForces)
   const [content, toggleModal] = useState<any>('')
+  const [removeRoleId, setRemoveRoleId] = useState<string>('')
+  const localRoles = useRef<Role[]>([]);
 
   const handleSwitch = (_item: Item): void => {
     const selectedForce = forcesData.findIndex(force => force.uniqid === _item.uniqid)
     setSelectedItem(selectedForce)
+    localRoles.current = []
     onSidebarClick && onSidebarClick(_item as ForceData)
   }
 
@@ -66,6 +66,26 @@ export const SettingForces: React.FC<PropTypes> = ({
       nextForces[selectedItem] = force
       // TODO: strip out un-necessary UI related metadata (`type: "ASSET-ITEM"`)
       handleChangeForces(nextForces)
+    }
+
+    const onNewRoleAdded = (role: Role) => {
+      localRoles.current.push(role)
+    }
+
+    const onRoleRemoved = (roles: Role[], key: number, handleChange: (changeItems: Item[]) => void) => {
+      if (localRoles.current.length) {
+        setRemoveRoleId(roles[key].roleId)
+      } else {
+        customDeleteHandler && customDeleteHandler(roles, key, handleChange)
+      }
+    }
+
+    const removeAddingRole = () => {
+      const nextForce = [...initialForces][selectedItem]
+      nextForce.roles = nextForce.roles.filter(r => r.roleId != removeRoleId)
+      localRoles.current = localRoles.current.filter(r => r.roleId !== removeRoleId)
+      handleChangeForce(nextForce)
+      setRemoveRoleId('')
     }
 
     const handleOnRejectedIcon = (rejected: any): void => {
@@ -138,6 +158,7 @@ export const SettingForces: React.FC<PropTypes> = ({
             return false
           })
         }
+        localRoles.current = []
         onSave(forcesData)
       }
     }
@@ -150,6 +171,7 @@ export const SettingForces: React.FC<PropTypes> = ({
     return (
       <div key={selectedItem}>
         <CustomDialog isOpen={!!content} cancelBtnText={'OK'} header='Error' onClose={onClose} >{content}</CustomDialog>
+        <Confirm isOpen={!!removeRoleId} message='This action is permanent. Are you sure?' onCancel={() => setRemoveRoleId('')} onConfirm={removeAddingRole} />
         <div className={cx(styles.row, styles['mb-20'])}>
           <div className={styles.col}>
             <TextInput
@@ -194,7 +216,8 @@ export const SettingForces: React.FC<PropTypes> = ({
               data={data}
               handleChangeForce={handleChangeForce}
               forces={forcesData}
-              customDeleteHandler={customDeleteHandler}
+              customDeleteHandler={onRoleRemoved}
+              onNewRoleAdded={onNewRoleAdded}
             />
 
             <AssetsAccordion

--- a/packages/components/src/local/organisms/setting-forces/settings-force-roles/__snapshots__/index.spec.tsx.snap
+++ b/packages/components/src/local/organisms/setting-forces/settings-force-roles/__snapshots__/index.spec.tsx.snap
@@ -138,35 +138,8 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                 >
                                   <div
                                     className="main"
-                                    title="Click to Copy or Edit"
+                                    title="Click to Edit"
                                   >
-                                    <section
-                                      className="input-container disable-offset"
-                                    >
-                                      <div
-                                        className="MuiFormControl-root MuiTextField-root"
-                                      >
-                                        <div
-                                          className="MuiInputBase-root MuiInput-root makeStyles-root-4 makeStyles-root-6 MuiInput-underline makeStyles-underline-5 makeStyles-underline-7 MuiInputBase-formControl MuiInput-formControl"
-                                          onClick={[Function]}
-                                        >
-                                          <input
-                                            aria-invalid={false}
-                                            autoFocus={false}
-                                            className="MuiInputBase-input MuiInput-input"
-                                            disabled={false}
-                                            name=""
-                                            onAnimationStart={[Function]}
-                                            onBlur={[Function]}
-                                            onChange={[Function]}
-                                            onFocus={[Function]}
-                                            required={false}
-                                            type="text"
-                                            value="rkrlw6f5f"
-                                          />
-                                        </div>
-                                      </div>
-                                    </section>
                                     <section
                                       className="password-mask"
                                     >
@@ -204,6 +177,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                     </section>
                                     <div
                                       className="key"
+                                      onClick={[Function]}
                                     >
                                       <svg
                                         className="svg-inline--fa fa-key"
@@ -224,7 +198,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                   >
                                     <span
                                       aria-disabled={false}
-                                      className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-8 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-9"
+                                      className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-4 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-1 MuiSwitch-colorSecondary PrivateSwitchBase-checked-5 Mui-checked WithStyles(ForwardRef(Switch))-checked-2"
                                       onBlur={[Function]}
                                       onDragLeave={[Function]}
                                       onFocus={[Function]}
@@ -243,7 +217,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                       >
                                         <input
                                           checked={true}
-                                          className="PrivateSwitchBase-input-14 MuiSwitch-input"
+                                          className="PrivateSwitchBase-input-7 MuiSwitch-input"
                                           disabled={false}
                                           onChange={[Function]}
                                           type="checkbox"
@@ -254,7 +228,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                       </span>
                                     </span>
                                     <span
-                                      className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-10"
+                                      className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-3"
                                     />
                                   </span>
                                   <div
@@ -274,7 +248,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                   >
                                     <span
                                       aria-disabled={false}
-                                      className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-8 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-9"
+                                      className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-4 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-1 MuiSwitch-colorSecondary PrivateSwitchBase-checked-5 Mui-checked WithStyles(ForwardRef(Switch))-checked-2"
                                       onBlur={[Function]}
                                       onDragLeave={[Function]}
                                       onFocus={[Function]}
@@ -293,7 +267,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                       >
                                         <input
                                           checked={true}
-                                          className="PrivateSwitchBase-input-14 MuiSwitch-input"
+                                          className="PrivateSwitchBase-input-7 MuiSwitch-input"
                                           disabled={false}
                                           onChange={[Function]}
                                           type="checkbox"
@@ -304,7 +278,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                       </span>
                                     </span>
                                     <span
-                                      className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-10"
+                                      className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-3"
                                     />
                                   </span>
                                   <div
@@ -324,7 +298,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                   >
                                     <span
                                       aria-disabled={false}
-                                      className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-8 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-9"
+                                      className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-4 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-1 MuiSwitch-colorSecondary PrivateSwitchBase-checked-5 Mui-checked WithStyles(ForwardRef(Switch))-checked-2"
                                       onBlur={[Function]}
                                       onDragLeave={[Function]}
                                       onFocus={[Function]}
@@ -343,7 +317,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                       >
                                         <input
                                           checked={true}
-                                          className="PrivateSwitchBase-input-14 MuiSwitch-input"
+                                          className="PrivateSwitchBase-input-7 MuiSwitch-input"
                                           disabled={false}
                                           onChange={[Function]}
                                           type="checkbox"
@@ -354,7 +328,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                       </span>
                                     </span>
                                     <span
-                                      className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-10"
+                                      className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-3"
                                     />
                                   </span>
                                   <div
@@ -374,7 +348,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                   >
                                     <span
                                       aria-disabled={false}
-                                      className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-8 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-9"
+                                      className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-4 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-1 MuiSwitch-colorSecondary PrivateSwitchBase-checked-5 Mui-checked WithStyles(ForwardRef(Switch))-checked-2"
                                       onBlur={[Function]}
                                       onDragLeave={[Function]}
                                       onFocus={[Function]}
@@ -393,7 +367,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                       >
                                         <input
                                           checked={true}
-                                          className="PrivateSwitchBase-input-14 MuiSwitch-input"
+                                          className="PrivateSwitchBase-input-7 MuiSwitch-input"
                                           disabled={false}
                                           onChange={[Function]}
                                           type="checkbox"
@@ -404,7 +378,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                       </span>
                                     </span>
                                     <span
-                                      className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-10"
+                                      className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-3"
                                     />
                                   </span>
                                   <div
@@ -457,35 +431,8 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                 >
                                   <div
                                     className="main"
-                                    title="Click to Copy or Edit"
+                                    title="Click to Edit"
                                   >
-                                    <section
-                                      className="input-container disable-offset"
-                                    >
-                                      <div
-                                        className="MuiFormControl-root MuiTextField-root"
-                                      >
-                                        <div
-                                          className="MuiInputBase-root MuiInput-root makeStyles-root-4 makeStyles-root-15 MuiInput-underline makeStyles-underline-5 makeStyles-underline-16 MuiInputBase-formControl MuiInput-formControl"
-                                          onClick={[Function]}
-                                        >
-                                          <input
-                                            aria-invalid={false}
-                                            autoFocus={false}
-                                            className="MuiInputBase-input MuiInput-input"
-                                            disabled={false}
-                                            name=""
-                                            onAnimationStart={[Function]}
-                                            onBlur={[Function]}
-                                            onChange={[Function]}
-                                            onFocus={[Function]}
-                                            required={false}
-                                            type="text"
-                                            value="rkrlasdd5f"
-                                          />
-                                        </div>
-                                      </div>
-                                    </section>
                                     <section
                                       className="password-mask"
                                     >
@@ -526,6 +473,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                     </section>
                                     <div
                                       className="key"
+                                      onClick={[Function]}
                                     >
                                       <svg
                                         className="svg-inline--fa fa-key"
@@ -541,7 +489,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                   >
                                     <span
                                       aria-disabled={false}
-                                      className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-8 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-9"
+                                      className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-4 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-1 MuiSwitch-colorSecondary PrivateSwitchBase-checked-5 Mui-checked WithStyles(ForwardRef(Switch))-checked-2"
                                       onBlur={[Function]}
                                       onDragLeave={[Function]}
                                       onFocus={[Function]}
@@ -560,7 +508,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                       >
                                         <input
                                           checked={true}
-                                          className="PrivateSwitchBase-input-14 MuiSwitch-input"
+                                          className="PrivateSwitchBase-input-7 MuiSwitch-input"
                                           disabled={false}
                                           onChange={[Function]}
                                           type="checkbox"
@@ -571,7 +519,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                       </span>
                                     </span>
                                     <span
-                                      className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-10"
+                                      className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-3"
                                     />
                                   </span>
                                 </div>
@@ -583,7 +531,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                   >
                                     <span
                                       aria-disabled={false}
-                                      className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-8 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-9"
+                                      className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-4 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-1 MuiSwitch-colorSecondary PrivateSwitchBase-checked-5 Mui-checked WithStyles(ForwardRef(Switch))-checked-2"
                                       onBlur={[Function]}
                                       onDragLeave={[Function]}
                                       onFocus={[Function]}
@@ -602,7 +550,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                       >
                                         <input
                                           checked={true}
-                                          className="PrivateSwitchBase-input-14 MuiSwitch-input"
+                                          className="PrivateSwitchBase-input-7 MuiSwitch-input"
                                           disabled={false}
                                           onChange={[Function]}
                                           type="checkbox"
@@ -613,7 +561,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                       </span>
                                     </span>
                                     <span
-                                      className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-10"
+                                      className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-3"
                                     />
                                   </span>
                                 </div>
@@ -625,7 +573,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                   >
                                     <span
                                       aria-disabled={false}
-                                      className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-8 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-9"
+                                      className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-4 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-1 MuiSwitch-colorSecondary PrivateSwitchBase-checked-5 Mui-checked WithStyles(ForwardRef(Switch))-checked-2"
                                       onBlur={[Function]}
                                       onDragLeave={[Function]}
                                       onFocus={[Function]}
@@ -644,7 +592,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                       >
                                         <input
                                           checked={true}
-                                          className="PrivateSwitchBase-input-14 MuiSwitch-input"
+                                          className="PrivateSwitchBase-input-7 MuiSwitch-input"
                                           disabled={false}
                                           onChange={[Function]}
                                           type="checkbox"
@@ -655,7 +603,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                       </span>
                                     </span>
                                     <span
-                                      className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-10"
+                                      className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-3"
                                     />
                                   </span>
                                 </div>
@@ -667,7 +615,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                   >
                                     <span
                                       aria-disabled={false}
-                                      className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-11 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-8 MuiSwitch-colorSecondary PrivateSwitchBase-checked-12 Mui-checked WithStyles(ForwardRef(Switch))-checked-9"
+                                      className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-4 MuiSwitch-switchBase WithStyles(ForwardRef(Switch))-switchBase-1 MuiSwitch-colorSecondary PrivateSwitchBase-checked-5 Mui-checked WithStyles(ForwardRef(Switch))-checked-2"
                                       onBlur={[Function]}
                                       onDragLeave={[Function]}
                                       onFocus={[Function]}
@@ -686,7 +634,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                       >
                                         <input
                                           checked={true}
-                                          className="PrivateSwitchBase-input-14 MuiSwitch-input"
+                                          className="PrivateSwitchBase-input-7 MuiSwitch-input"
                                           disabled={false}
                                           onChange={[Function]}
                                           type="checkbox"
@@ -697,7 +645,7 @@ exports[`RolesAccordion component: renders correctly 1`] = `
                                       </span>
                                     </span>
                                     <span
-                                      className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-10"
+                                      className="MuiSwitch-track WithStyles(ForwardRef(Switch))-track-3"
                                     />
                                   </span>
                                 </div>

--- a/packages/components/src/local/organisms/setting-forces/settings-force-roles/index.spec.tsx
+++ b/packages/components/src/local/organisms/setting-forces/settings-force-roles/index.spec.tsx
@@ -1,7 +1,8 @@
+import { ForceData } from '@serge/custom-types'
+import { forces } from '@serge/mocks'
+import { noop } from 'lodash'
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { forces } from '@serge/mocks'
-import { ForceData } from '@serge/custom-types'
 import RolesAccordion from './index'
 
 const handleChange = (obj: ForceData): void => {
@@ -16,6 +17,7 @@ describe('RolesAccordion component:', () => {
           data={forces[0]}
           handleChangeForce={handleChange}
           forces={forces}
+          onNewRoleAdded={noop}
         />,
         { createNodeMock: () => document.createElement('textarea') }
       )

--- a/packages/components/src/local/organisms/setting-forces/settings-force-roles/index.stories.tsx
+++ b/packages/components/src/local/organisms/setting-forces/settings-force-roles/index.stories.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react'
 
 // Import component files
-import RolesAccordion from './index'
-import docs from './README.md'
-import { withKnobs } from '@storybook/addon-knobs'
 import { watuWargame } from '@serge/mocks'
+import { withKnobs } from '@storybook/addon-knobs'
+import { noop } from 'lodash'
+import docs from './README.md'
+import RolesAccordion from './index'
 
 const forcesMock = watuWargame.data.forces.forces
 
@@ -27,6 +28,7 @@ export const Default: React.FC = () => {
     data={data}
     handleChangeForce={(nextData): void => setData(nextData)}
     forces={forcesMock}
+    onNewRoleAdded={noop}
   />
 }
 

--- a/packages/components/src/local/organisms/setting-forces/settings-force-roles/index.tsx
+++ b/packages/components/src/local/organisms/setting-forces/settings-force-roles/index.tsx
@@ -7,20 +7,20 @@ import PropTypes from './types/props'
 import styles from './styles.module.scss'
 
 /* Import Components */
-import cx from 'classnames'
-import Switch from '@material-ui/core/Switch'
-import { withStyles } from '@material-ui/core/styles'
+import { faBookReader, faCaretDown, faChessKing, faComments, faEye } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCaretDown, faEye, faComments, faBookReader, faChessKing } from '@fortawesome/free-solid-svg-icons'
-import SortableList, { Item as SortableListItem } from '../../../molecules/sortable-list'
-import FormGroup from '../../../atoms/form-group-shadow'
 import Accordion from '@material-ui/core/Accordion'
 import AccordionDetails from '@material-ui/core/AccordionDetails'
 import AccordionSummary from '@material-ui/core/AccordionSummary'
+import Switch from '@material-ui/core/Switch'
 import Typography from '@material-ui/core/Typography'
-import PasswordView from '../../../molecules/password-view'
-import { getUniquePasscode } from '@serge/helpers'
+import { withStyles } from '@material-ui/core/styles'
 import { NEW_ROLE } from '@serge/config'
+import { getUniquePasscode } from '@serge/helpers'
+import cx from 'classnames'
+import FormGroup from '../../../atoms/form-group-shadow'
+import PasswordView from '../../../molecules/password-view'
+import SortableList, { Item as SortableListItem } from '../../../molecules/sortable-list'
 
 const MobileSwitch = withStyles({
   switchBase: {
@@ -36,7 +36,7 @@ const MobileSwitch = withStyles({
   track: {}
 })(Switch)
 
-export const RolesAccordion: FC<PropTypes> = ({ data, handleChangeForce, forces, customDeleteHandler }) => {
+export const RolesAccordion: FC<PropTypes> = ({ data, handleChangeForce, forces, customDeleteHandler, onNewRoleAdded }) => {
   const renderRoleFields = (item: SortableListItem, key: number): React.ReactNode => {
     const roleItem = item as Role
     const handleChangeRole = (nextRole: Role, submitPlans = false): void => {
@@ -98,15 +98,16 @@ export const RolesAccordion: FC<PropTypes> = ({ data, handleChangeForce, forces,
   }
 
   const handleCreateRole = (): void => {
-    const roles: Array<Role> = [...data.roles, {
+    const newRole = {
       roleId: getUniquePasscode(forces, 'r'),
       name: NEW_ROLE,
       isGameControl: false,
       isInsightViewer: false,
       isRFIManager: false,
       isObserver: false
-    }]
-
+    }
+    const roles: Array<Role> = [...data.roles, newRole]
+    onNewRoleAdded(newRole)
     handleChangeForce({ ...data, roles: roles })
   }
 

--- a/packages/components/src/local/organisms/setting-forces/settings-force-roles/index.tsx
+++ b/packages/components/src/local/organisms/setting-forces/settings-force-roles/index.tsx
@@ -135,7 +135,7 @@ export const RolesAccordion: FC<PropTypes> = ({ data, handleChangeForce, forces,
                 items={data.roles}
                 title='Add Role'
                 customDeleteHandler={customDeleteHandler}
-                valueOnEmpty={NEW_ROLE}
+                valueOnEmpty=''
               />
             </FormGroup>
           </div>

--- a/packages/components/src/local/organisms/setting-forces/settings-force-roles/types/props.d.ts
+++ b/packages/components/src/local/organisms/setting-forces/settings-force-roles/types/props.d.ts
@@ -1,4 +1,4 @@
-import { ForceData } from '@serge/custom-types'
+import { ForceData, Role } from '@serge/custom-types'
 import { Item } from '../../molecules/sortable-list'
 
 export default interface PropTypes {
@@ -7,4 +7,5 @@ export default interface PropTypes {
   forces: ForceData[]
   /** Handler for when user tries to delete role with Game Control privileges */
   customDeleteHandler?: (NewItems: Item[], key: number, handleChange: (changedItems: Item[]) => void) => void
+  onNewRoleAdded: (role: Role) => void
 }

--- a/packages/helpers/src/handle-channel-updates.ts
+++ b/packages/helpers/src/handle-channel-updates.ts
@@ -136,7 +136,8 @@ export const handleAllInitialChannelMessages = (
   allForces: ForceData[],
   chatChannel: PlayerUiChatChannel,
   isObserver: boolean,
-  allTemplatesByKey: TemplateBodysByKey
+  allTemplatesByKey: TemplateBodysByKey,
+  isUmpire: boolean
 ): SetWargameMessage => {
   const forceId: string | undefined = selectedForce ? selectedForce.uniqid : undefined
   const messagesReduced: Array<MessageChannel> = payload.map((message) => {
@@ -171,7 +172,7 @@ export const handleAllInitialChannelMessages = (
       templates
     } = getParticipantStates(channel, forceId, selectedRole, isObserver, allTemplatesByKey)
 
-    if (isObserver || isParticipant) {
+    if ((isUmpire && isObserver) || isParticipant) {
       // TODO: define type for force Icons
       const forceIcons: any[] = []
       const forceColors: string[] = []

--- a/packages/helpers/src/tests/handle-initial-channel-messages.spec.ts
+++ b/packages/helpers/src/tests/handle-initial-channel-messages.spec.ts
@@ -24,7 +24,7 @@ describe('handle initial channel creation', () => {
     const payload: Array<MessageInfoType | MessageCustom> = AdminMessagesMock.concat(GameMessagesMockRFI).concat(InfoMessagesMock) as Array<MessageInfoType | MessageCustom>
     const revPayload = payload.reverse()
     const res: SetWargameMessage = handleAllInitialChannelMessages(revPayload, 'wargame-name', blueForce, selectedRole, allChannels,
-      allForces, chatChannel, isObserver, allTemplates)
+      allForces, chatChannel, isObserver, allTemplates, true)
 
     expect(res).toBeTruthy()
     expect(res.chatChannel.messages.length).toEqual(2) // turn marker
@@ -51,7 +51,7 @@ describe('handle new message into RFI channel', () => {
 
     // initialise wargame
     const res: SetWargameMessage = handleAllInitialChannelMessages(payload, 'wargame-name', blueForce, selectedRole, allChannels,
-      allForces, chatChannel, isObserver, allTemplates)
+      allForces, chatChannel, isObserver, allTemplates, true)
 
     const newBlue1 = res.channels['channel-BlueRFI']
     expect(newBlue1).toBeTruthy()


### PR DESCRIPTION
Fixes #2671 

- [x] While adding a new force, under the roles tab, the key icon is not clickable
- [x] While adding a new force, under the roles tab, the user is unable to delete a role before saving the force.
- [x] The user is unable to completely remove the role name while renaming it.
- [x] Roles access toggle are still enabled even after umpire toggle is off
- [ ] Default force selected for new channel, but roles not displayed until deselect and reselect force: _**Unable to reproduce**_
- [ ] Saving a new channel with "restricted access" and "template" field in the Participants and Messages table only removes the "template" field if the table is not saved first: _**Unable to reproduce**_