### PR TITLE
'Filter Out' button in Core mapping should not overlap the text

### DIFF
--- a/client/src/Components/local/atoms/core-mapping/styles.module.scss
+++ b/client/src/Components/local/atoms/core-mapping/styles.module.scss
@@ -4,7 +4,7 @@
 
   button {
     position: absolute;
-    bottom: 0;
+    top: 0;
     z-index: 1112;
     padding: 0;
     min-width: 40px;


### PR DESCRIPTION
Fixes #2787 

![image](https://github.com/serge-web/serge/assets/26705621/79258323-8ca5-4d16-bc3b-aa8d535a4e69)
