### PR TITLE
2827 Show generic "shape" symbol for core shapes

### DIFF
--- a/client/src/Components/local/atoms/mapping-panel/helpers/icon-renderer.tsx
+++ b/client/src/Components/local/atoms/mapping-panel/helpers/icon-renderer.tsx
@@ -1,8 +1,13 @@
+import { faShapes } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { FormControlLabel, Radio } from '@material-ui/core'
 import { Feature, GeoJsonProperties, Geometry } from 'geojson'
+import { get } from 'lodash'
 import ms from 'milsymbol'
 import React, { ChangeEvent, useEffect, useRef } from 'react'
+import * as ReactDOMServer from 'react-dom/server'
 import { calculateHealthColor } from 'src/Helpers'
+import { RENDERER_MILSYM } from 'src/custom-types'
 import styles from '../styles.module.scss'
 
 type IconRendererProps = {
@@ -15,16 +20,21 @@ const IconRenderer: React.FC<IconRendererProps> = ({ feature, checked, onClick }
   const iconRef = useRef<HTMLDivElement>(null)
  
   useEffect(() => {
+    if (!feature) {
+      return
+    }
     // TODO: reserch how to render shape in this line
     const icon = new ms.Symbol(feature.properties?.sidc, { size: 20 })
-    const health = feature.properties?.health
+    const health = feature.properties?.health || 100
 
     const healthColor = calculateHealthColor(health)
 
     if (iconRef.current) {
       iconRef.current.innerHTML = `
         <div class="${styles['asset-icon']}">
-          ${icon.asDOM().outerHTML}
+          ${get(feature, 'properties._type') === RENDERER_MILSYM
+        ? icon.asDOM().outerHTML
+        : ReactDOMServer.renderToString(<FontAwesomeIcon icon={faShapes} color={feature.properties?.color} fontSize={25} />)} 
           <div class="${styles['health-bar']}" style="background-color: ${healthColor};"></div>
         </div>
       `


### PR DESCRIPTION
Fixes #2827 

<img width="467" alt="image" src="https://github.com/serge-web/serge/assets/26705621/69c15239-2765-4e6d-af1a-9d51b291966b">
