### PR TITLE
Re-use string consts, to ensure consistent case in phase naming

### DIFF
--- a/client/src/config/enums.ts
+++ b/client/src/config/enums.ts
@@ -2,6 +2,7 @@
  * list the possible phases in a wargame
  */
 export enum Phase {
+  // note: ensure case is same as in globals file
   /* players are planning their next turn
    */
   Planning = 'planning',

--- a/client/src/config/enums.ts
+++ b/client/src/config/enums.ts
@@ -1,14 +1,12 @@
-import { ADJUDICATION_PHASE, PLANNING_PHASE } from "./globals";
-
 /**
  * list the possible phases in a wargame
  */
 export enum Phase {
   /* players are planning their next turn
    */
-  Planning = PLANNING_PHASE,
+  Planning = 'planning',
   /** umpire is resolving planned turns */
-  Adjudication = ADJUDICATION_PHASE
+  Adjudication = 'adjudication'
 }
 
 /** increasing permissions in a collaborative editing channel

--- a/client/src/config/enums.ts
+++ b/client/src/config/enums.ts
@@ -1,12 +1,14 @@
+import { ADJUDICATION_PHASE, PLANNING_PHASE } from "./globals";
+
 /**
  * list the possible phases in a wargame
  */
 export enum Phase {
   /* players are planning their next turn
    */
-  Planning = 'planning',
+  Planning = PLANNING_PHASE,
   /** umpire is resolving planned turns */
-  Adjudication = 'adjudication'
+  Adjudication = ADJUDICATION_PHASE
 }
 
 /** increasing permissions in a collaborative editing channel


### PR DESCRIPTION
Fixes #2980 